### PR TITLE
Defined WorkspaceClientCapabilites to fix Eclipse JDT LS errors

### DIFF
--- a/src/general.rs
+++ b/src/general.rs
@@ -9,7 +9,9 @@ use url::Url;
 pub fn initialize(root_path: &str, meta: EditorMeta, ctx: &mut Context) {
     let params = InitializeParams {
         capabilities: ClientCapabilities {
-            workspace: None,
+            workspace: Some(WorkspaceClientCapabilites {
+                ..WorkspaceClientCapabilites::default()
+            }),
             text_document: Some(TextDocumentClientCapabilities {
                 synchronization: None,
                 completion: Some(CompletionCapability {


### PR DESCRIPTION
## Overview
This addresses a null pointer exception that is thrown by the Eclipse JDT language server (https://github.com/eclipse/eclipse.jdt.ls) when the workspace has no capabilities defined.

## Analysis
The null pointer is thrown here: https://github.com/eclipse/eclipse.jdt.ls/blob/f364a491a701add3639c42803b0afc8da6df4b50/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java#L95
Which is called from here: https://github.com/eclipse/eclipse.jdt.ls/blob/edffe44f04172cc05174df43f1acf220427f202d/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java#L157

I can provide any additional information required, etc.

Edit:

Also note the typo in WorkspaceClientCapabilities. The typo is on their end: https://github.com/gluon-lang/languageserver-types/blob/master/src/lib.rs#L636