### PR TITLE
Debug messages, improved completion and cquery semantic highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,7 @@ version = "0.1.0"
 dependencies = [
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "languageserver-types 0.36.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -166,6 +167,7 @@ dependencies = [
  "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ clap = "2"
 crossbeam-channel = "0"
 fnv="1"
 jsonrpc-core = "8"
+enum_primitive = "0.1.0"
 languageserver-types = "0"
 regex = "0"
 serde = "1"
@@ -15,6 +16,7 @@ serde_derive = "1"
 serde_json = "1"
 toml = "0"
 url = "1"
+url_serde = "0.2.0"
 
 [profile.release]
 lto = true

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1,6 +1,9 @@
-decl str lsp_cmd 'nc localhost 31337'
+decl str lsp_cmd 'nc localhost 31337 -c'
 decl -hidden completions lsp_completions
-decl -hidden range-specs lsp_errors 
+decl -hidden range-specs lsp_errors
+
+#cquery
+decl -hidden range-specs cquery_semhl
 
 def lsp-did-change %{
     decl -hidden str lsp_draft %sh{ mktemp }
@@ -100,6 +103,7 @@ method  = "textDocument/didSave"
 def lsp-enable %{
     set buffer completers "option=lsp_completions:%opt{completers}"
     add-highlighter buffer/ ranges lsp_errors
+    add-highlighter buffer/ ranges cquery_semhl
 
     lsp-did-open
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -26,6 +26,7 @@ fn get_server_cmd(config: &Config, language_id: &str) -> Option<(String, Vec<Str
 }
 
 pub fn start(config: &Config) {
+    println!("Starting Controller");
     let (editor_tx, editor_rx) = editor_transport::start(config);
     let mut controllers: FnvHashMap<Route, Sender<EditorRequest>> = FnvHashMap::default();
     for request in editor_rx {
@@ -211,6 +212,12 @@ fn dispatch_server_notification(method: &str, params: Params, mut ctx: &mut Cont
         notification::PublishDiagnostics::METHOD => {
             diagnostics::publish_diagnostics(
                 params.parse().expect("Failed to parse params"),
+                &mut ctx,
+            );
+        }
+        "$cquery/publishSemanticHighlighting" => {
+            cquery::publish_semantic_highlighting(
+                params.parse().expect("Failed to parse semhl params"),
                 &mut ctx,
             );
         }

--- a/src/editor_transport.rs
+++ b/src/editor_transport.rs
@@ -28,6 +28,7 @@ pub fn start(config: &Config) -> (Sender<EditorResponse>, Receiver<RoutedEditorR
     let (reader_tx, reader_rx) = bounded(1024);
     let languages = config.language.clone();
     thread::spawn(move || {
+        println!("Starting editor transport on {}:{}", ip, port);
         let addr = SocketAddr::new(ip, port);
 
         let listener = TcpListener::bind(&addr).expect("Failed to start TCP server");
@@ -38,6 +39,7 @@ pub fn start(config: &Config) -> (Sender<EditorResponse>, Receiver<RoutedEditorR
             stream
                 .read_to_string(&mut request)
                 .expect("Failed to read from TCP stream");
+            println!("Request: {}", request);
             let request: EditorRequest =
                 toml::from_str(&request).expect("Failed to parse editor request");
             let session = request.meta.session.clone();

--- a/src/language_features/cquery.rs
+++ b/src/language_features/cquery.rs
@@ -1,0 +1,208 @@
+use types::*;
+use context::*;
+use url::Url;
+use languageserver_types::{Range, NumberOrString};
+use url_serde;
+use serde;
+
+enum_from_primitive!{
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub enum StorageClass {
+    Invalid = 0,
+    No = 1,
+    Extern = 2,
+    Static = 3,
+    PrivateExtern = 4,
+    Auto = 5,
+    Register = 6
+}
+}
+
+impl<'de> serde::Deserialize<'de> for StorageClass {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use enum_primitive::FromPrimitive;
+
+        let i = try!(u8::deserialize(deserializer));
+        Ok(StorageClass::from_u8(i).unwrap_or(StorageClass::Invalid))
+    }
+}
+
+impl serde::Serialize for StorageClass {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u8(*self as u8)
+    }
+}
+
+enum_from_primitive!{
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub enum SemanticSymbolKind {
+    Unknown = 0,
+    File = 1,
+    Module = 2,
+    Namespace = 3,
+    Package = 4,
+
+    Class = 5,
+    Method = 6,
+    Property = 7,
+    Field = 8,
+    Constructor = 9,
+
+    Enum = 10,
+    Interface = 11,
+    Function = 12,
+    Variable = 13,
+    Constant = 14,
+
+    String = 15,
+    Number = 16,
+    Boolean = 17,
+    Array = 18,
+    Object = 19,
+
+    Key = 20,
+    Null = 21,
+    EnumMember = 22,
+    Struct = 23,
+    Event = 24,
+
+    Operator = 25,
+    TypeParameter = 26,
+
+    TypeAlias = 252,
+    Parameter = 253,
+    StaticMethod = 254,
+    Macro = 255,
+}
+}
+
+impl<'de> serde::Deserialize<'de> for SemanticSymbolKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use enum_primitive::FromPrimitive;
+
+        let i = try!(u8::deserialize(deserializer));
+        Ok(SemanticSymbolKind::from_u8(i).unwrap_or(SemanticSymbolKind::Unknown))
+    }
+}
+
+impl serde::Serialize for SemanticSymbolKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u8(*self as u8)
+    }
+}
+
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SemanticSymbol {
+    stable_id: NumberOrString,
+    parent_kind: SemanticSymbolKind,
+    kind: SemanticSymbolKind,
+    is_type_member: Option<bool>,
+    storage: StorageClass,
+    ranges: Vec<Range>,
+}
+
+impl SemanticSymbol {
+    
+    /// Get the face for this symbol
+    pub fn get_face(&self) -> String {
+        match self.kind {
+            SemanticSymbolKind::Class | SemanticSymbolKind::Struct => "cqueryTypes",
+            SemanticSymbolKind::Enum => "cqueryEnums",
+            SemanticSymbolKind::TypeAlias => "cqueryTypeAliases",
+            SemanticSymbolKind::TypeParameter => "cqueryTemplateParameters",
+            SemanticSymbolKind::Function => "cqueryFreeStandingFunctions",
+            SemanticSymbolKind::Method | SemanticSymbolKind::Constructor => "cqueryMemberFunctions",
+            SemanticSymbolKind::StaticMethod => "cqueryStaticMemberFunctions",
+            SemanticSymbolKind::Variable => {
+                match self.parent_kind {
+                    SemanticSymbolKind::Function => "cqueryFreeStandingVariables",
+                    _ => "cqueryGlobalVariables",
+                }
+            },
+            SemanticSymbolKind::Field => {
+                match self.storage {
+                    StorageClass::Static => "cqueryStaticMemberVariables",
+                    _ => "cqueryMemberVariables",
+                }
+            },
+            SemanticSymbolKind::Parameter => "cqueryParameters",
+            SemanticSymbolKind::EnumMember => "cqueryEnumConstants",
+            SemanticSymbolKind::Namespace => "cqueryNamespaces",
+            SemanticSymbolKind::Macro => "cqueryMacros",
+            _ => "",
+        }.to_string()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PublishSemanticHighlightingParams {
+    /// The URI for which diagnostic information is reported.
+    #[serde(with = "url_serde")]
+    pub uri: Url,
+
+    /// The symbols to highlight
+    pub symbols: Vec<SemanticSymbol>,
+}
+
+pub fn publish_semantic_highlighting(params: PublishSemanticHighlightingParams, ctx: &mut Context) {
+    let session = ctx.session.clone();
+    let client = None;
+    let buffile = params.uri.path().to_string();
+    let version = ctx.versions.get(&buffile);
+    if version.is_none() {
+        return;
+    }
+    let version = *version.unwrap();
+    let ranges = params
+        .symbols
+        .iter()
+        .flat_map(|x| {
+            let face = x.get_face();
+            x.ranges
+            .iter()
+            .filter_map(move |r| {
+                if face.is_empty() {
+                    println!("No face found for {:?}", x);
+                    Option::None
+                } else {
+                    Option::Some(format!(
+                        "{}.{},{}.{}|{}",
+                        r.start.line + 1,
+                        r.start.character + 1,
+                        r.end.line + 1,
+                        // LSP ranges are exclusive, but Kakoune's are inclusive
+                        r.end.character,
+                        face,
+                    ))
+                }
+            })
+        })
+        .collect::<Vec<String>>()
+        .join(":");
+    let command = format!(
+        "eval -buffer %§{}§ %§set buffer cquery_semhl \"{}:{}\"§",
+        buffile, version, ranges
+    );
+    let meta = EditorMeta {
+        session,
+        client,
+        buffile,
+        version,
+    };
+    ctx.exec(meta, command.to_string());
+}

--- a/src/language_features/mod.rs
+++ b/src/language_features/mod.rs
@@ -1,3 +1,4 @@
 pub mod completion;
 pub mod definition;
 pub mod hover;
+pub mod cquery;

--- a/src/language_server_transport.rs
+++ b/src/language_server_transport.rs
@@ -8,6 +8,7 @@ use std::thread;
 use types::*;
 
 pub fn start(cmd: &str, args: &[String]) -> (Sender<ServerMessage>, Receiver<ServerMessage>) {
+    println!("Starting Language server {}", cmd);
     let mut child = Command::new(cmd)
         .args(args)
         .stdin(Stdio::piped())

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,9 @@ extern crate serde_derive;
 extern crate serde;
 extern crate toml;
 extern crate url;
+extern crate url_serde;
+#[macro_use]
+extern crate enum_primitive;
 
 mod types;
 mod project_root;


### PR DESCRIPTION
Right, this has a few things, because as always, i forgot to commit in the middle of playing around. I understand if you want me to split it up or only want some parts.

I added some debug messages because i couldnt get it working, and wanted to know what was going on. Turned out you need to add the `-c` flag to gnu-netcat - if that flag doesnt work on OSX, we can remove it and put a note in the readme.

Then i changed completion to

 - use `insertText` by default, instead of `label`
 - display the `label` in the menu, with `kind` next to it, formatted as `MenuInfo`
 - display `detail` and `doc` in the info box.

This plays a lot nicer with cquery and most other lsps, and shouldnt be a problem for any.

Lastly, the whole point of me looking at this, is to switch the cquery plugin to using this, so i added cquery semantic highlighting. Now, i dont know if you want this in the upstream. On the one hand, its fairly simple and self contained, on the other, you may want to keep the repo official lsp stuff only.
Anyway, the cquery stuff should give no issues with non-cquery lsps.

This is the first time i've ever touched rust, so I'm sorry if something is completely off. It does all work nicely though, and great job on this, i think this is the right way to do lsp for kakoune (which is nice, cause  there are at least 3 implementations out there)