### PR TITLE
Fix completion of dollar prefixed variables

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -52,7 +52,7 @@ def -hidden lsp-completion -docstring "Request completions for the main cursor p
     decl -hidden str lsp_completion_offset
 
     eval -draft %{ try %{
-        execute-keys <esc><a-h>s\w+.\z<ret>
+        execute-keys <esc><a-h>s\$?\w+.\z<ret>
         set window lsp_completion_offset %sh{echo $((${#kak_selection} - 1))}
     } catch %{
         set window lsp_completion_offset "0"

--- a/src/language_features/completion.rs
+++ b/src/language_features/completion.rs
@@ -41,7 +41,7 @@ pub fn editor_completion(
         CompletionResponse::Array(items) => items,
         CompletionResponse::List(list) => list.items,
     };
-    let re = Regex::new(r"(?P<c>[:|$])").unwrap();
+    let re = Regex::new(r"(?P<c>[:|])").unwrap();
     let maxlen = items.iter().map(|x| x.label.len()).max().unwrap_or(0);
 
     let items = items


### PR DESCRIPTION
While using a php language server (which I also added to the wiki). I noticed that completion of variables prefixed with a `$` results in something like `$\$variable`.

This is the result of two things in the code.

# 1 

In rc/kak.lsp, the regex selecting the word that is to be replaced by the completion only takes \w characters. 
I changed it so that it also selects the leading `$`.
This results in variables completed to `\$variable`, which is a bit better.

# 2

In src/language_features/completion.rs the characters `[:|$]` are escaped.
I do not see a problem with removing this escaping, so I would gladly see pointed out why this escaping is necessary.

For now, disabling the escaping for the return entry fixes the issue.
