### PR TITLE
Add bash language server

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -69,3 +69,9 @@ extensions = ["go"]
 roots = ["Gopkg.toml", "go.mod", ".git", ".hg"]
 command = "go-langserver"
 args = ["-mode", "stdio", "-gocodecompletion"]
+
+[language.bash]
+extensions = ["sh", "bash", "zsh"]
+roots = [".git", ".hg"]
+command = "bash-language-server"
+args = ["start"]


### PR DESCRIPTION
The "go to definition" and completions are useful even for zsh, so until there is a dedicated zsh language server, let's keep this enabled for zsh as well.