### PR TITLE
Add line-flags for diagnostics

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1,6 +1,8 @@
 # faces used by inline diagnostics
 set-face global DiagnosticError red
 set-face global DiagnosticWarning yellow
+# Line flags for errors and warnings both use this face
+set-face global LineFlagErrors red
 
 decl str lsp_cmd '{{cmd}} --request {{args}}'
 
@@ -15,8 +17,13 @@ decl str lsp_completion_trigger %{execute-keys '<a-h><a-k>\S.\z<ret>'}
 # doesn't handle well nested function calls
 decl str lsp_hover_insert_mode_trigger %{execute-keys '<a-f>(s\A[^)]+\z<ret>'}
 
+
+decl str lsp_diagnostic_line_error_sign '*'
+decl str lsp_diagnostic_line_warning_sign '!'
+
 decl -hidden completions lsp_completions
 decl -hidden range-specs lsp_errors
+decl -hidden line-specs lsp_error_lines
 decl -hidden range-specs cquery_semhl
 decl -hidden str lsp_draft
 decl -hidden int lsp_timestamp -1
@@ -273,6 +280,14 @@ def lsp-inline-diagnostics-disable -docstring "Disable inline diagnostics highli
     remove-highlighter global/lsp_errors
 }
 
+def lsp-diagnostic-lines-enable -docstring "Enable diagnostics line flags" %{
+    add-highlighter global/lsp_error_lines flag-lines LineFlagErrors lsp_error_lines
+}
+
+def lsp-diagnostic-lines-disable -docstring "Disable diagnostics line flags"  %{
+    remove-highlighter global/lsp_error_lines
+}
+
 def lsp-auto-hover-enable -docstring "Enable auto-requesting hover info for current position" %{
     hook -group lsp-auto-hover global NormalIdle .* %{
         lsp-hover
@@ -316,8 +331,10 @@ def -hidden lsp-enable -docstring "Default integration with kak-lsp" %{
     set global completers option=lsp_completions %opt{completers}
     add-highlighter global/cquery_semhl ranges cquery_semhl
     lsp-inline-diagnostics-enable
+    lsp-diagnostic-lines-enable
 
     map global goto d '<esc>:lsp-definition<ret>' -docstring 'definition'
+    map global goto r '<esc>:lsp-references<ret>' -docstring 'references'
 
     hook -group lsp global BufCreate .* %{
         lsp-did-open


### PR DESCRIPTION
Ive been missing this for some time, its really useful when scrolling through a file looking for errors.

Currently theres no way to set individual faces for each line spec, so errors and warnings both use the same face `LineFlagErrors´. However, the characters are customizable with the options `lsp_diagnostics_line_{error,warning}_sign`. It defaults to `*` for errors and `!` for warnings. Then the user can feel free to use whatever fancy unincode character they want.

I dont really know anything about rust, so i may have duplicated a little too much code, but it works, and is probably easy to clean up