### PR TITLE
Implement workspace/didChangeConfiguration support

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -113,6 +113,10 @@ To know which subset of kak-lsp commands is backed by current buffer filetype's 
 
 == Configuration
 
+kak-lsp itself has configuration, but it also adds configuration options to Kakoune that affect the Kakoune integration..
+
+=== Configuring kak-lsp
+
 kak-lsp is configured via configuration file in https://github.com/toml-lang/toml[TOML] format. By default kak-lsp tries to read `$HOME/.config/kak-lsp/kak-lsp.toml`, but you can override it with command-line option `--config`.
 
 Look into the default `kak-lsp.toml` in the root of repository, it should be quite self-descriptive.
@@ -130,6 +134,40 @@ If you are setting any options to server via cli do not forget to append them to
 `~/.config/kak-lsp/kak-lsp.toml` file.
 
 Please let us know if you have any ideas about how to make default config more sensible.
+
+=== Configuring Kakoune
+
+kak-lsp's Kakoune integration declares the following options:
+
+* `lsp_completion_trigger` (str): This option is set to a Kakoune command, which is executed every time the user pauses in insert mode. If the command succeeds, kak-lsp will send a completion request to the language server.
+* `lsp_diagnostic_line_error_sign` (str): When using `lsp-diagnostic-lines-enable` and the language server detects an error, kak-lsp will add a flag to the left-most column of the window, using this string and the `LineFlagErrors` face.
+* `lsp_diagnostic_line_warning_sign` (str): When using `lsp-diagnostic-lines-enable` and the language server detects an warning, kak-lsp will add a flag to the left-most column of the window, using this string and the `LineFlagErrors` face.
+* `lsp_hover_anchor` (bool): When using `lsp-hover` or `lsp-auto-hover-enable`, if this option is `true` then the hover information will be displayed next to the active selection. Otherwise, the information will be displayed in a box in the lower-right corner.
+* `lsp_hover_insert_mode_trigger` (str): This option is set to a Kakoune command. When using `lsp-auto-hover-insert-mode-enable`, this command is executed every time the user pauses in insert mode. If the command succeeds, kak-lsp will send a hover-information request for the text selected by the command.
+* `lsp_insert_spaces` (bool): When using `lsp-formatting`, if this option is `true`, kak-lsp will ask the language server to indent with spaces rather than tabs.
+* `lsp_server_configuration` (str-to-str-map): At startup, and when this option is modified, kak-lsp will send its contents to the language server in a `workspace/DidChangeConfiguration` notification. Some languages servers allow dynamic configuration in this way. See below for more information about this option.
+* `lsp_tab_size` (int): When using `lsp-formatting`, kak-lsp will ask the language server to assume tabs are this many spaces wide. It's similar to the standard Kakoune option `indent_width`.
+
+The `lsp_server_configuration` option is unusual, since the language server wants deeply-nested JSON objects, which are hard to represent in Kakoune. If a language server's documentation says it wants a structure like this:
+
+[source=json]
+----
+{
+    "settings": {
+        "rust": {
+            "clippy_preference": "on"
+        }
+    }
+}
+----
+
+...you can achieve the same thing in Kakoune with:
+
+----
+set-option global lsp_server_configuration rust.clippy_preference="on"
+----
+
+That is, the keys of the `lsp_server_configuration` option are a `.`-delimited path of JSON objects. For implementation reasons, the values use TOML serialisation rules rather than JSON rules, but they're pretty much the same thing for strings, numbers and booleans, which are the most common configuration types.
 
 == Troubleshooting
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use text_sync::*;
 use toml;
 use types::*;
+use workspace;
 
 type Controllers = FnvHashMap<Route, Sender<EditorRequest>>;
 
@@ -324,6 +325,9 @@ fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
         }
         notification::DidSaveTextDocument::METHOD => {
             text_document_did_save(params, meta, &mut ctx);
+        }
+        notification::DidChangeConfiguration::METHOD => {
+            workspace::did_change_configuration(params, meta, &mut ctx);
         }
         request::Completion::METHOD => {
             completion::text_document_completion(params, meta, &mut ctx);

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ mod project_root;
 mod text_sync;
 mod types;
 mod util;
+mod workspace;
 
 use clap::{App, Arg};
 use daemonize::Daemonize;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,0 +1,96 @@
+use context::*;
+use languageserver_types::DidChangeConfigurationParams;
+use serde_json;
+use toml;
+use types::*;
+
+use languageserver_types::notification::{self, Notification};
+
+fn insert_value<'a, 'b, P>(
+    target: &'b mut serde_json::map::Map<String, serde_json::Value>,
+    mut path: P,
+    local_key: String,
+    value: serde_json::Value,
+) -> Result<(), String>
+    where P: Iterator<Item=&'a str>,
+    P: 'a
+{
+    match path.next() {
+        Some(key) => {
+            let mut maybe_new_target = target
+                .entry(key)
+                .or_insert_with(|| serde_json::Value::Object(
+                    serde_json::Map::new()
+                )).as_object_mut();
+
+            if maybe_new_target.is_none() {
+                return Err(format!(
+                    "Expected path {:?} to be object, found {:?}",
+                    key,
+                    &maybe_new_target,
+                ));
+            }
+
+            insert_value(
+                maybe_new_target.unwrap(),
+                path,
+                local_key,
+                value,
+            )
+        }
+        None => {
+            match target.insert(local_key, value) {
+                Some(old_value) => Err(format!("Replaced old value: {:?}", old_value)),
+                None => Ok(()),
+            }
+        }
+    }
+}
+
+pub fn did_change_configuration(
+    params: EditorParams,
+    _meta: &EditorMeta,
+    ctx: &mut Context,
+) {
+    let default_settings = toml::value::Table::new();
+
+    let raw_settings = params
+        .as_table()
+        .and_then(|t| t.get("settings"))
+        .and_then(|val| val.as_table())
+        .unwrap_or_else(|| &default_settings);
+
+    let mut settings = serde_json::Map::new();
+
+    for (raw_key, raw_value) in raw_settings.iter() {
+        let mut key_parts = raw_key.split('.');
+        let local_key = match key_parts.next_back() {
+            Some(name) => name,
+            None => {
+                warn!("Got a setting with an empty local name: {:?}", raw_key);
+                continue
+            }
+        };
+
+        let value: serde_json::Value = match raw_value.clone().try_into() {
+            Ok(value) => value,
+            Err(e) => {
+                warn!("Could not convert setting {:?} to JSON: {}", raw_value, e,);
+                continue
+            }
+        };
+
+        match insert_value(&mut settings, key_parts, local_key.into(), value) {
+            Ok(_) => (),
+            Err(e) => {
+                warn!("Could not set {:?} to {:?}: {}", raw_key, raw_value, e);
+                continue
+            }
+        }
+    }
+
+    let params = DidChangeConfigurationParams {
+        settings: serde_json::Value::Object(settings)
+    };
+    ctx.notify(notification::DidChangeConfiguration::METHOD.into(), params);
+}


### PR DESCRIPTION
Added the `lsp_server_configuration` option and associated glue to `lsp.kak`.

Added a new `workspace.rs` module for `workspace/*` notifications.

`workspace::did_change_configuration()` is pretty straight-forward, but actually creating the nested JSON objects from dotted keys was surprisingly difficult. I wound up making a recursive helper method (`insert_value`) because I couldn't get the iterative version past the borrow checker.

I added documentation for the `lsp_server_configuration` option to `README.asciidoc` and since none of the other options were mentioned, I documented them too.

If you want to try this out yourself and you're using Rust 1.29 or higher with the RLS installed, you can use the command listed in the README to request Clippy warnings, and then open `workspace.rs`. It'll complain that the `params` argument is passed by value but only used by reference so it could safely be passed  by reference instead (I ignored that suggestion to match all the other calls in `controller.rs`).