### PR TITLE
Send initialized notification

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -472,6 +472,7 @@ fn dispatch_server_response(
                     .expect("Failed to parse initialized response")
                     .capabilities,
             );
+            ctx.notify(notification::Initialized::METHOD.into(), InitializedParams {});
             let mut requests = Vec::with_capacity(ctx.pending_requests.len());
             for msg in ctx.pending_requests.drain(..) {
                 requests.push(msg);


### PR DESCRIPTION
According to the spec, the client must send initialized notification
before sending any other requests or notifications.

https://microsoft.github.io/language-server-protocol/specification#initialized

>The initialized notification is sent from the client to the server after the client received the result of the initialize request but before the client is sending any other request or notification to the server. The server can use the initialized notification for example to dynamically register capabilities. The initialized notification may only be sent once.
