### PR TITLE
Simplify poisoning pattern

### DIFF
--- a/src/general.rs
+++ b/src/general.rs
@@ -50,6 +50,7 @@ pub fn exit(_params: EditorParams, _meta: &EditorMeta, ctx: &mut Context) {
     ctx.notify(notification::Exit::METHOD.into(), params);
     ctx.lang_srv_poison_tx.send(());
     ctx.controller_poison_tx.send(());
+    ctx.lang_srv_tx = None;
 }
 
 pub fn capabilities(_params: EditorParams, meta: &EditorMeta, ctx: &mut Context) {


### PR DESCRIPTION
I took a quick peek at the code and I think I've identified one of the major sources of complexity here: the `posoned_tx_rx` pattern. It is used to cancel stuff all over the place. However in Rust we have a wonderful tool for cancellation: RAII (I've even [blogged](https://matklad.github.io/2018/03/02/stopping-a-rust-worker.html) about it). 

The main idea is that, instead of doing `select!(receiver, poison)`, we just do `for msg in receiver` and treat a closed receiver as a shutdown signal. A cool thing about this pattern is that it automatically works when the sender is dropped due to panic. 

I've applied it only in one instance, but it should be applicable to other uses of poisoned channels as well. 

I am also not sure that this particular patch actually works: I don't have a good understanding of interactions between various actors, however, I am pretty sure this patch could be tweaked to work.

