### PR TITLE
Daemonize in a current working directory

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,11 @@ fn main() {
         let session = config.server.session.as_ref().unwrap_or(&config.server.ip);
         let mut pid_path = util::temp_dir();
         pid_path.push(format!("{}.pid", session));
-        if matches.is_present("daemonize") && Daemonize::new().pid_file(&pid_path).start().is_err()
+        if matches.is_present("daemonize") && Daemonize::new()
+            .pid_file(&pid_path)
+            .working_directory(std::env::current_dir().unwrap())
+            .start()
+            .is_err()
         {
             error!("Failed to daemonize process");
             goodbye(&config, 1);


### PR DESCRIPTION
It looks like `rls` does not work correctly if cwd was changed to `/`. I can hardly see downsides of deamonizing in the cwd, so I propose this as a patch, and I will fill an issue against rls.