### PR TITLE
Add D language config

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -80,3 +80,8 @@ args = ["start"]
 filetypes = ["dart"]
 roots = ["pubspec.yaml", ".git"]
 command = "dart_language_server"
+
+[language.d]
+filetypes = ["d", "di"]
+roots = [".git", "dub.sdl", "dub.json"]
+command = "dls"


### PR DESCRIPTION
A minor addition to the default toml configuration file to support the D language using [dsl](https://github.com/d-language-server/dls/blob/v0.18.2/README.md).  If this PR is accepted I will also plan to update the Wiki page to guide the user through installing dsl.