### PR TITLE
Update install instructions for Arch Linux

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -29,6 +29,12 @@ mv kak-lsp.toml ~/.config/kak-lsp/
 
 ==== Linux
 
+===== Package managers
+
+* Arch Linux: `pacman -S kak-lsp` or https://aur.archlinux.org/packages/kak-lsp-git/[AUR/kak-lsp-git]
+
+===== Others
+
 ----
 wget https://github.com/ul/kak-lsp/releases/download/v5.10.0/kak-lsp-v5.10.0-x86_64-unknown-linux-musl.tar.gz
 tar xzvf kak-lsp-v5.10.0-x86_64-unknown-linux-musl.tar.gz
@@ -54,8 +60,6 @@ mv kak-lsp.toml ~/.config/kak-lsp/
 ----
 
 === From the source
-
-NOTE: ArchLinux users can automate most of the following steps with the https://aur.archlinux.org/packages/kak-lsp-git/[kak-lsp-git] AUR package.
 
 ----
 git clone https://github.com/ul/kak-lsp


### PR DESCRIPTION
I added `kak-lsp` to the official package repository for Arch Linux. 

Hopefully other distros will package it too at some point, so I proactively created a whole new section `Package managers` 😄 