### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+PKGNAME ?= kak-lsp
+PREFIX ?= /usr
+
+BIN_DIR = $(DESTDIR)$(PREFIX)/bin
+SHARE_DIR = $(DESTDIR)$(PREFIX)/share
+
+.PHONY: build install
+
+build:
+	cargo build --release --locked
+
+install:
+	install -Dm755 -t "$(BIN_DIR)" target/release/$(PKGNAME)
+	install -Dm644 -t "$(SHARE_DIR)/$(PKGNAME)/examples/" $(PKGNAME).toml
+	install -Dm644 -t "$(SHARE_DIR)/$(PKGNAME)/rc/" rc/lsp.kak
+	install -Dm644 UNLICENSE "$(SHARE_DIR)/licenses/$(PKGNAME)/LICENSE"


### PR DESCRIPTION
I'd like to have a Makefile in the repo, being the source of truth for how to install the app.

This will allow me and everyone else use `$ make` to compile the binary and `$ make install` to install it.