### PR TITLE
Fix error when executing lsp-find-error without arguments

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -635,11 +635,11 @@ Jump to the next or previous diagnostic error" %{
     evaluate-commands %sh{
         previous=false
         errorCompare="DiagnosticError"
-        if [ $1 = "--previous" ]; then
+        if [ "$1" = "--previous" ]; then
             previous=true
             shift
         fi
-        if [ $1 = "--include-warnings" ]; then
+        if [ "$1" = "--include-warnings" ]; then
             errorCompare="Diagnostic"
         fi
         #expand quoting, stores option in $@


### PR DESCRIPTION
shell stderr: <<<
sh: line 3: [: =: unary operator expected
sh: line 7: [: =: unary operator expected
>>>