### PR TITLE
Proper loading by plugin managers

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -87,8 +87,8 @@ plug "ul/kak-lsp" do %{
 }
 ----
 
-You can replace `cargo install` with `ln -s target/release/kak-lsp ~/.local/bin/`
-where `~/local/bin/` can be replaced to something in your `$PATH`.
+You can replace `cargo install` with `ln -sf target/release/kak-lsp ~/.local/bin/`
+where `~/.local/bin/` can be replaced to something in your `$PATH`.
 
 == Language servers
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -80,12 +80,12 @@ cp kak-lsp.toml ~/.config/kak-lsp/
 If you don't mind using plugin manager, you can install kak-lsp
 with https://github.com/andreyorst/plug.kak[plug.kak]. Add this code to your `kakrc`:
 
----
+----
 plug "ul/kak-lsp" do %{
     cargo build --release
     cargo install
 }
----
+----
 
 You can replace `cargo install` with `ln -s target/release/kak-lsp ~/.local/bin/`
 where `~/local/bin/` can be replaced to something in your `$PATH`.

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -23,8 +23,8 @@ tar xzvf kak-lsp-v6.0.0-x86_64-apple-darwin.tar.gz
 # replace `~/.local/bin/` with something on your `$PATH`
 mv kak-lsp ~/.local/bin/
 
-mkdir -p ~/.config/kak-lsp 
-mv kak-lsp.toml ~/.config/kak-lsp/ 
+mkdir -p ~/.config/kak-lsp
+mv kak-lsp.toml ~/.config/kak-lsp/
 ----
 
 ==== Linux
@@ -42,8 +42,8 @@ tar xzvf kak-lsp-v6.0.0-x86_64-unknown-linux-musl.tar.gz
 # replace `~/.local/bin/` with something on your `$PATH`
 mv kak-lsp ~/.local/bin/
 
-mkdir -p ~/.config/kak-lsp 
-mv kak-lsp.toml ~/.config/kak-lsp/ 
+mkdir -p ~/.config/kak-lsp
+mv kak-lsp.toml ~/.config/kak-lsp/
 ----
 
 ==== FreeBSD
@@ -55,8 +55,8 @@ tar xzvf kak-lsp-v6.0.0-x86_64-unknown-freebsd.tar.gz
 # replace `~/.local/bin/` with something on your `$PATH`
 mv kak-lsp ~/.local/bin/
 
-mkdir -p ~/.config/kak-lsp 
-mv kak-lsp.toml ~/.config/kak-lsp/ 
+mkdir -p ~/.config/kak-lsp
+mv kak-lsp.toml ~/.config/kak-lsp/
 ----
 
 === From the source
@@ -70,10 +70,25 @@ cargo build --release
 # replace `~/.local/bin/` with something on your `$PATH`
 ln -s $PWD/target/release/kak-lsp ~/.local/bin/
 
-mkdir -p ~/.config/kak-lsp 
+mkdir -p ~/.config/kak-lsp
 # or just link if you are okay with default config
 cp kak-lsp.toml ~/.config/kak-lsp/
 ----
+
+=== With plug.kak
+
+If you don't mind using plugin manager, you can install kak-lsp
+with https://github.com/andreyorst/plug.kak[plug.kak]. Add this code to your `kakrc`:
+
+---
+plug "ul/kak-lsp" do %{
+    cargo build --release
+    cargo install
+}
+---
+
+You can replace `cargo install` with `ln -s target/release/kak-lsp ~/.local/bin/`
+where `~/local/bin/` can be replaced to something in your `$PATH`.
 
 == Language servers
 

--- a/plugin.kak
+++ b/plugin.kak
@@ -1,2 +1,0 @@
-source 'rc/lsp.kak'
-set global lsp_cmd "%opt{plug_install_dir}/kak-lsp/target/release/kak-lsp"


### PR DESCRIPTION
Ok. So I've read some code, and come to conclusion that there's no need in `plugin.kak` at all.

Your plugin is now loading perfectly fine with `plug`, and can be loaded in the same way without it by simply sorcing `lsp.kak`:

```kak
plug "andreyorst/kak-lsp" do %{
    cargo build --release
    cargo install
}
```
This PR fixes #117.

I've also did bit of refactoring by replacing all short commands with standard ones, like `decl` to `declare-option`. Are there any tests for kakscript so I could check if I didn't break anything?