### PR TITLE
 lsp-did-open: send text from kakoune to kak-lsp

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -167,15 +167,15 @@ pub fn start(
 
 fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
     let buffile = &request.meta.buffile;
-    if !buffile.is_empty() && !ctx.versions.contains_key(buffile) {
-        text_document_did_open(&request.meta, &mut ctx);
-    }
     let meta = &request.meta;
     let params = request.params;
     let method: &str = &request.method;
+    if !buffile.is_empty() && !ctx.versions.contains_key(buffile) {
+        text_document_did_open(&request.meta, params.clone(), &mut ctx);
+    }
     match method {
         notification::DidOpenTextDocument::METHOD => {
-            text_document_did_open(meta, &mut ctx);
+            text_document_did_open(meta, params, &mut ctx);
         }
         notification::DidChangeTextDocument::METHOD => {
             text_document_did_change(meta, params, &mut ctx);

--- a/src/types.rs
+++ b/src/types.rs
@@ -105,6 +105,11 @@ pub struct EditorCompletion {
 }
 
 #[derive(Deserialize, Debug)]
+pub struct TextDocumentDidOpenParams {
+    pub draft: String,
+}
+
+#[derive(Deserialize, Debug)]
 pub struct TextDocumentDidChangeParams {
     pub draft: String,
 }


### PR DESCRIPTION
kak-lsp is used to read a file's content from a filesystem on `didOpen` before sending it to a language server, and this is something that does not work in case we are dealing with newly created (unsaved) file. In order to fix that problem, we need to send a buffer context from kakoune directly to kak-lsp, similarly to `didChange` message.

Closes #156 