### PR TITLE
Use bingo for Go

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -67,8 +67,7 @@ args = ["--lsp"]
 [language.go]
 filetypes = ["go"]
 roots = ["Gopkg.toml", "go.mod", ".git", ".hg"]
-command = "go-langserver"
-args = ["-mode", "stdio", "-gocodecompletion"]
+command = "bingo"
 
 [language.bash]
 filetypes = ["sh"]


### PR DESCRIPTION
[Go modules](https://github.com/golang/go/wiki/Modules) were introduced in 1.11 in 2018 and will become the default in 1.13 this year. Many people have already switched to using them. 

`go-langserver` [doesn't support](https://github.com/sourcegraph/go-langserver/issues/316) Go modules, thus [`bingo` was born](https://github.com/sourcegraph/go-langserver/issues/316#issuecomment-441412860). I've tested it today, works quite well, and indeed supports Go modules.

Go devs are also working on the official language server called `golsp`, but it is still in very early development.

I propose to change the default to `bingo`, and in future reconsider switching to the official `golsp` once it becomes stable.

See also [Differences between go-langserver, bingo, golsp](https://github.com/saibing/bingo#differences-between-go-langserver-bingo-golsp)