### PR TITLE
add --path . to plug installation method

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -84,7 +84,7 @@ with https://github.com/andreyorst/plug.kak[plug.kak]. Add this code to your `ka
 ----
 plug "ul/kak-lsp" do %{
     cargo build --release --locked
-    cargo install --force
+    cargo install --force --path .
 }
 ----
 


### PR DESCRIPTION
This is weird, but today my cargo ranted on me that I'm not able to use `cargo install`:
```
error: Using `cargo install` to install the binaries for the package in current working directory is no longer supported, use `cargo install --path .` instead
```