### PR TITLE
Allow project roots to be specified by environment

### DIFF
--- a/src/project_root.rs
+++ b/src/project_root.rs
@@ -1,7 +1,18 @@
 use glob::glob;
+use std::collections::HashSet;
+use std::env;
 use std::path::PathBuf;
 
-pub fn find_project_root(roots: &[String], path: &str) -> String {
+pub fn find_project_root(language: &str, markers: &[String], path: &str) -> String {
+    let vars = gather_env_roots(language);
+    if vars.is_empty() {
+        roots_by_marker(markers, path)
+    } else {
+        roots_by_env(&vars, path).unwrap_or_else(|| roots_by_marker(markers, path))
+    }
+}
+
+pub fn roots_by_marker(roots: &[String], path: &str) -> String {
     let mut pwd = PathBuf::from(path);
     if pwd.is_file() {
         pwd.pop();
@@ -23,4 +34,27 @@ pub fn find_project_root(roots: &[String], path: &str) -> String {
             return src;
         }
     }
+}
+
+pub fn gather_env_roots(language: &str) -> HashSet<PathBuf> {
+    let prefix = format!("KAK_LSP_PROJECT_ROOT_{}", language.to_uppercase());
+    debug!("Searching for vars starting with {}", prefix);
+    env::vars()
+        .into_iter()
+        .filter(|(k, _v)| k.starts_with(&prefix))
+        .map(|(_k, v)| PathBuf::from(v))
+        .collect()
+}
+
+pub fn roots_by_env(roots: &HashSet<PathBuf>, path: &str) -> Option<String> {
+    let p = PathBuf::from(path);
+    let pwd = if p.is_file() {
+        p.parent().unwrap().to_path_buf()
+    } else {
+        p
+    };
+    roots
+        .iter()
+        .find(|x| pwd.starts_with(&x))
+        .map(|x| x.to_str().unwrap().to_string())
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -107,7 +107,7 @@ pub fn start(config: &Config, initial_request: Option<String>) -> i32 {
                 }
                 let language_id = language_id.unwrap();
 
-                let root_path = find_project_root(&languages[language_id].roots, &request.meta.buffile);
+                let root_path = find_project_root(&language_id, &languages[language_id].roots, &request.meta.buffile);
                 let route = Route {
                     session: request.meta.session.clone(),
                     language: language_id.clone(),


### PR DESCRIPTION
Allow per language marker files to be overridden by directly specifying
the project root for a given buffer. When searching for the project root
for a buffer first see if there are any environment variables prefixed
by `KAK_LSP_PROJECT_ROOT_%LANG%`. If so then iterate over all matching
variable values checking if they are a prefix of the path to the current
buffer. If so the first matching prefix is selected as the project root,
else return the buffers path. If there are no matching environment
variables then proceed as before.