### PR TITLE
Add docstrings for the various diagnostics-related commands.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -131,6 +131,7 @@ It adds:
 * `lsp-workspace-symbol-incr` command to incrementally list project-wide symbols matching the query
 * `lsp-diagnostics` command to list project-wide diagnostics (current buffer determines project and language to collect diagnostics)
 * inline diagnostics highlighting using `DiagnosticError` and `DiagnosticWarning` faces; could be disabled with `lsp-inline-diagnostics-disable` command
+* flags in the left margin on lines with errors or warnings; could be disabled with `lsp-diagnostic-lines-disable` command
 * `lsp-formatting` command to format current buffer
 * `lsp-formatting-sync` command to format current buffer synchronously, suitable for use with `BufWritePre` hook:
 

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -792,19 +792,19 @@ define-command lsp-workspace-symbol-incr -docstring "Open buffer with an increme
 
 ### Hooks and highlighters ###
 
-define-command lsp-inline-diagnostics-enable -params 1 -docstring "Enable inline diagnostics highlighting" %{
+define-command lsp-inline-diagnostics-enable -params 1 -docstring "lsp-inline-diagnostics-enable <scope>: Enable inline diagnostics highlighting for <scope>" %{
     add-highlighter "%arg{1}/lsp_errors" ranges lsp_errors
 }
 
-define-command lsp-inline-diagnostics-disable -params 1 -docstring "Disable inline diagnostics highlighting"  %{
+define-command lsp-inline-diagnostics-disable -params 1 -docstring "lsp-inline-diagnostics-disable <scope>: Disable inline diagnostics highlighting for <scope>"  %{
     remove-highlighter "%arg{1}/lsp_errors"
 }
 
-define-command lsp-diagnostic-lines-enable -params 1 -docstring "Enable diagnostics line flags" %{
+define-command lsp-diagnostic-lines-enable -params 1 -docstring "lsp-diagnostic-lines-enable <scope>: Show flags on lines with diagnostics in <scope>" %{
     add-highlighter "%arg{1}/lsp_error_lines" flag-lines LineFlagErrors lsp_error_lines
 }
 
-define-command lsp-diagnostic-lines-disable -params 1 -docstring "Disable diagnostics line flags"  %{
+define-command lsp-diagnostic-lines-disable -params 1 -docstring "lsp-diagnostic-lines-disable <scope>: Hide flags on lines with diagnostics in <scope>"  %{
     remove-highlighter "%arg{1}/lsp_error_lines"
 }
 


### PR DESCRIPTION
I was having difficulty getting diagnostic flags to show up, and found it frustrating that  `lsp-diagnostic-lines-enable` sounded like it should do what I wanted, but instead it just complained "wrong argument count".

It turns out my actual problem was I hadn't called `lsp-enable`, but I figure more detailed docstrings never hurt.