### PR TITLE
Send window/progress messages to editor

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -685,6 +685,11 @@ define-command -hidden lsp-replace-selection -params 1 -docstring %{
     nop %sh{ rm $kak_opt_lsp_text_edit_tmp }
 }
 
+define-command -hidden lsp-handle-progress -params 4 -docstring %{
+  lsp-handle-progress <title> <message> <percentage> <done>
+  Handle progress messages sent from the language server. Override to handle this.
+} %{ nop }
+
 ### Handling requests from server ###
 
 define-command -hidden lsp-get-server-initialization-options -params 1 -docstring %{

--- a/src/context.rs
+++ b/src/context.rs
@@ -111,4 +111,27 @@ impl Context {
         self.request_counter += 1;
         id
     }
+
+    pub fn meta_for_session(&self) -> EditorMeta {
+        EditorMeta {
+            session: self.session.clone(),
+            client: None,
+            buffile: "".to_string(),
+            filetype: "".to_string(), // filetype is not used by ctx.exec, but it's definitely a code smell
+            version: 0,
+            fifo: None,
+        }
+    }
+
+    pub fn meta_for_buffer(&self, buffile: String) -> Option<EditorMeta> {
+        let document = self.documents.get(&buffile)?;
+        Some(EditorMeta {
+            session: self.session.clone(),
+            client: None,
+            buffile: buffile,
+            filetype: "".to_string(), // filetype is not used by ctx.exec, but it's definitely a code smell
+            version: document.version,
+            fifo: None,
+        })
+    }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -263,10 +263,32 @@ fn dispatch_server_notification(method: &str, params: Option<Params>, mut ctx: &
             debug!("Language server exited");
         }
         "window/logMessage" => {
-            debug!("{:?}", params);
+            debug!("{:?}", &params);
+            let params: LogMessageParams = params
+                .unwrap()
+                .parse()
+                .expect("Failed to parse LogMessageParams params");
+            ctx.exec(
+                ctx.meta_for_session(),
+                format!("echo -debug {}", editor_quote(&params.message)),
+            );
         }
         "window/progress" => {
-            debug!("{:?}", params);
+            debug!("{:?}", &params);
+            let params: WindowProgress = params
+                .unwrap()
+                .parse()
+                .expect("Failed to parse WindowProgress params");
+            ctx.exec(
+                ctx.meta_for_session(),
+                format!(
+                    "lsp-handle-progress {} {} {} {}",
+                    editor_quote(&params.title),
+                    editor_quote(&params.message.unwrap_or_default()),
+                    editor_quote(&params.percentage.unwrap_or_default()),
+                    editor_quote(params.done.map_or("", |_| "done"))
+                ),
+            );
         }
         "telemetry/event" => {
             debug!("{:?}", params);

--- a/src/types.rs
+++ b/src/types.rs
@@ -141,6 +141,14 @@ pub struct TextDocumentRenameParams {
     pub new_name: String,
 }
 
+#[derive(Deserialize, Debug)]
+pub struct WindowProgress {
+    pub title: String,
+    pub message: Option<String>,
+    pub percentage: Option<String>,
+    pub done: Option<bool>,
+}
+
 // Language Server
 
 // XXX serde(untagged) ?


### PR DESCRIPTION
Rust Language Server sends useful progress messages to communicate what it is doing, and the VS Code rust extension displays them in the statusbar.

This allows users to override the `lsp-handle-progress` command. For example: 
```
declare-option -hidden str modeline_progress ""
define-command -hidden -params 4 -override lsp-handle-progress %{
  set global modeline_progress %sh{
    echo $1${2:+": $2"}${3:+" $3%"}${4:+" ✓"}
  }
}
```
And then put `%opt{modeline_progress}` in your `modelinefmt` to see what RLS is doing.