### PR TITLE
Use callbacks instead of a separate dispatch function for responses

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,8 +1,11 @@
 use crate::types::*;
 use crossbeam_channel::Sender;
-use jsonrpc_core::{self, Call, Id, Params, Version};
+use jsonrpc_core::{self, Call, Id, Params, Value, Version};
+use lsp_types::notification::Notification;
+use lsp_types::request::*;
 use lsp_types::*;
 use ropey;
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;
 
@@ -17,6 +20,10 @@ pub struct Document {
     pub text: ropey::Rope,
 }
 
+// FnOnce doesn't work yet, so we use FnMut for now
+// https://github.com/rust-lang/rust/issues/28796
+pub type ResponseCallback = Box<FnMut(&mut Context, EditorMeta, Value) -> ()>;
+
 pub struct Context {
     pub capabilities: Option<ServerCapabilities>,
     pub config: Config,
@@ -26,7 +33,7 @@ pub struct Context {
     pub language_id: String,
     pub pending_requests: Vec<EditorRequest>,
     pub request_counter: u64,
-    pub response_waitlist: HashMap<Id, (EditorMeta, String, EditorParams)>,
+    pub response_waitlist: HashMap<Id, (EditorMeta, &'static str, ResponseCallback)>,
     pub root_path: String,
     pub session: SessionId,
     pub documents: HashMap<String, Document>,
@@ -61,23 +68,51 @@ impl Context {
         }
     }
 
-    pub fn call(&mut self, id: Id, method: String, params: impl ToParams) {
+    pub fn call<
+        R: Request,
+        F: for<'a> FnOnce(&'a mut Context, EditorMeta, R::Result) -> () + 'static,
+    >(
+        &mut self,
+        meta: EditorMeta,
+        params: R::Params,
+        callback: F,
+    ) where
+        R::Params: ToParams,
+        R::Result: for<'a> Deserialize<'a>,
+    {
         let params = params.to_params();
         if params.is_err() {
             error!("Failed to convert params");
             return;
         }
+        let id = self.next_request_id();
+        let mut callback = Some(callback);
+        self.response_waitlist.insert(
+            id.clone(),
+            (
+                meta,
+                R::METHOD,
+                Box::new(move |ctx, meta, val| {
+                    let result = serde_json::from_value(val).expect("Failed to parse response");
+                    // This is a hack because Box<FnOnce> doesn't work yet
+                    callback.take().unwrap()(ctx, meta, result)
+                }),
+            ),
+        );
         let call = jsonrpc_core::MethodCall {
             jsonrpc: Some(Version::V2),
             id,
-            method,
+            method: R::METHOD.into(),
             params: Some(params.unwrap()),
         };
         self.lang_srv_tx
             .send(ServerMessage::Request(Call::MethodCall(call)));
     }
 
-    pub fn notify(&mut self, method: String, params: impl ToParams) {
+    pub fn notify<N: Notification>(&mut self, params: N::Params)
+    where
+        N::Params: ToParams,
+    {
         let params = params.to_params();
         if params.is_err() {
             error!("Failed to convert params");
@@ -85,7 +120,7 @@ impl Context {
         }
         let notification = jsonrpc_core::Notification {
             jsonrpc: Some(Version::V2),
-            method,
+            method: N::METHOD.into(),
             // NOTE this is required because jsonrpc serializer converts Some(None) into []
             params: match params.unwrap() {
                 Params::None => None,
@@ -106,7 +141,7 @@ impl Context {
         }
     }
 
-    pub fn next_request_id(&mut self) -> Id {
+    fn next_request_id(&mut self) -> Id {
         let id = Id::Num(self.request_counter);
         self.request_counter += 1;
         id

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -84,7 +84,7 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
     ctx.exec(meta, command.to_string());
 }
 
-pub fn editor_diagnostics(meta: &EditorMeta, ctx: &mut Context) {
+pub fn editor_diagnostics(meta: EditorMeta, ctx: &mut Context) {
     let content = ctx
         .diagnostics
         .iter()
@@ -118,5 +118,5 @@ pub fn editor_diagnostics(meta: &EditorMeta, ctx: &mut Context) {
         editor_quote(&ctx.root_path),
         editor_quote(&content),
     );
-    ctx.exec(meta.clone(), command);
+    ctx.exec(meta, command);
 }

--- a/src/language_features/references.rs
+++ b/src/language_features/references.rs
@@ -3,16 +3,15 @@ use crate::position::*;
 use crate::types::*;
 use crate::util::*;
 use itertools::Itertools;
-use lsp_types::request::Request;
+use lsp_types::request::*;
 use lsp_types::*;
 use ropey::Rope;
 use serde::Deserialize;
-use serde_json::{self, Value};
 use std::fs::File;
 use std::io::BufReader;
 use url::Url;
 
-pub fn text_document_references(meta: &EditorMeta, params: EditorParams, ctx: &mut Context) {
+pub fn text_document_references(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
     let req_params = PositionParams::deserialize(params.clone()).unwrap();
     let req_params = ReferenceParams {
         text_document: TextDocumentIdentifier {
@@ -23,75 +22,68 @@ pub fn text_document_references(meta: &EditorMeta, params: EditorParams, ctx: &m
             include_declaration: true,
         },
     };
-    let id = ctx.next_request_id();
-    ctx.response_waitlist.insert(
-        id.clone(),
-        (meta.clone(), request::References::METHOD.into(), params),
-    );
-    ctx.call(id, request::References::METHOD.into(), req_params);
+    ctx.call::<References, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
+        editor_references(meta, result, ctx)
+    });
 }
 
-pub fn editor_references(meta: &EditorMeta, result: Value, ctx: &mut Context) {
-    let result = serde_json::from_value(result).expect("Failed to parse references response");
-    if let Some(mut locations) = match result {
-        ReferencesResponse::Array(locations) => Some(locations),
-        ReferencesResponse::None => None,
-    } {
-        // Sort locations by (filename, line)
-        locations.sort_unstable_by_key(|location| {
-            (location.uri.to_file_path(), location.range.start.line)
-        });
-
-        let content = locations
-            .iter()
-            .group_by(|location| location.uri.to_file_path())
-            .into_iter()
-            .map(|(filename, group)| {
-                let filename = filename.unwrap();
-                let file = File::open(&filename);
-                let name = filename
-                    .strip_prefix(&ctx.root_path)
-                    .ok()
-                    .and_then(|p| Some(p.to_str().unwrap()))
-                    .or_else(|| filename.to_str())
-                    .unwrap();
-
-                if file.is_err() {
-                    error!("Failed to open referenced file: {}", name);
-                    return group.map(|_loc| String::new()).join("\n");
-                }
-                let text = Rope::from_reader(BufReader::new(file.unwrap())).unwrap();
-                group
-                    .map(|location| {
-                        let position = location.range.start;
-                        let loc_line = position.line as usize;
-                        if loc_line < text.len_lines() {
-                            let line = text.line(loc_line);
-                            let p = lsp_position_to_kakoune(&position, &text, &ctx.offset_encoding);
-                            format!("{}:{}:{}:{}", name, p.line, p.column, line)
-                        } else {
-                            error!(
-                                "End of file reached, line {} not found in {}",
-                                loc_line, name,
-                            );
-                            String::from("\n")
-                        }
-                    })
-                    .join("")
-            })
-            .join("");
-
-        let command = format!(
-            "lsp-show-references {} {}",
-            editor_quote(&ctx.root_path),
-            editor_quote(&content),
-        );
-        ctx.exec(meta.clone(), command);
+pub fn editor_references(meta: EditorMeta, result: Option<Vec<Location>>, ctx: &mut Context) {
+    let mut locations = match result {
+        Some(locations) => locations,
+        None => return,
     };
+    // Sort locations by (filename, line)
+    locations
+        .sort_unstable_by_key(|location| (location.uri.to_file_path(), location.range.start.line));
+
+    let content = locations
+        .iter()
+        .group_by(|location| location.uri.to_file_path())
+        .into_iter()
+        .map(|(filename, group)| {
+            let filename = filename.unwrap();
+            let file = File::open(&filename);
+            let name = filename
+                .strip_prefix(&ctx.root_path)
+                .ok()
+                .and_then(|p| Some(p.to_str().unwrap()))
+                .or_else(|| filename.to_str())
+                .unwrap();
+
+            if file.is_err() {
+                error!("Failed to open referenced file: {}", name);
+                return group.map(|_loc| String::new()).join("\n");
+            }
+            let text = Rope::from_reader(BufReader::new(file.unwrap())).unwrap();
+            group
+                .map(|location| {
+                    let position = location.range.start;
+                    let loc_line = position.line as usize;
+                    if loc_line < text.len_lines() {
+                        let line = text.line(loc_line);
+                        let p = lsp_position_to_kakoune(&position, &text, &ctx.offset_encoding);
+                        format!("{}:{}:{}:{}", name, p.line, p.column, line)
+                    } else {
+                        error!(
+                            "End of file reached, line {} not found in {}",
+                            loc_line, name,
+                        );
+                        String::from("\n")
+                    }
+                })
+                .join("")
+        })
+        .join("");
+    let command = format!(
+        "lsp-show-references {} {}",
+        editor_quote(&ctx.root_path),
+        editor_quote(&content),
+    );
+    ctx.exec(meta, command);
 }
 
 pub fn text_document_references_highlight(
-    meta: &EditorMeta,
+    meta: EditorMeta,
     params: EditorParams,
     ctx: &mut Context,
 ) {
@@ -105,29 +97,22 @@ pub fn text_document_references_highlight(
             include_declaration: true,
         },
     };
-    let id = ctx.next_request_id();
-    ctx.response_waitlist.insert(
-        id.clone(),
-        (
-            meta.clone(),
-            "textDocument/referencesHighlight".into(),
-            params,
-        ),
-    );
-    ctx.call(id, request::References::METHOD.into(), req_params);
+    ctx.call::<References, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
+        editor_references_highlight(meta, result, ctx)
+    });
 }
 
-pub fn editor_references_highlight(meta: &EditorMeta, result: Value, ctx: &mut Context) {
-    let result = serde_json::from_value(result).expect("Failed to parse references response");
+pub fn editor_references_highlight(
+    meta: EditorMeta,
+    result: Option<Vec<Location>>,
+    ctx: &mut Context,
+) {
     let document = ctx.documents.get(&meta.buffile);
     if document.is_none() {
         return;
     }
     let document = document.unwrap();
-    if let Some(mut locations) = match result {
-        ReferencesResponse::Array(locations) => Some(locations),
-        ReferencesResponse::None => None,
-    } {
+    if let Some(mut locations) = result {
         // Sort locations by (filename, line)
         locations.sort_unstable_by_key(|location| {
             (location.uri.to_file_path(), location.range.start.line)
@@ -149,6 +134,6 @@ pub fn editor_references_highlight(meta: &EditorMeta, result: Value, ctx: &mut C
             "set-option window lsp_references {} {}",
             meta.version, ranges,
         );
-        ctx.exec(meta.clone(), command);
+        ctx.exec(meta, command);
     };
 }

--- a/src/language_features/signature_help.rs
+++ b/src/language_features/signature_help.rs
@@ -1,41 +1,32 @@
 use crate::context::*;
 use crate::types::*;
 use crate::util::*;
-use lsp_types::request::Request;
+use lsp_types::request::*;
 use lsp_types::*;
 use serde::Deserialize;
-use serde_json::{self, Value};
 use url::Url;
 
-pub fn text_document_signature_help(meta: &EditorMeta, params: EditorParams, ctx: &mut Context) {
-    let req_params = PositionParams::deserialize(params.clone()).unwrap();
+pub fn text_document_signature_help(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
+    let params = PositionParams::deserialize(params).unwrap();
     let req_params = TextDocumentPositionParams {
         text_document: TextDocumentIdentifier {
             uri: Url::from_file_path(&meta.buffile).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &req_params.position, ctx).unwrap(),
+        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
     };
-    let id = ctx.next_request_id();
-    ctx.response_waitlist.insert(
-        id.clone(),
-        (
-            meta.clone(),
-            request::SignatureHelpRequest::METHOD.into(),
-            params,
-        ),
+    ctx.call::<SignatureHelpRequest, _>(
+        meta,
+        req_params,
+        move |ctx: &mut Context, meta, result| editor_signature_help(meta, params, result, ctx),
     );
-    ctx.call(id, request::SignatureHelpRequest::METHOD.into(), req_params);
 }
 
 pub fn editor_signature_help(
-    meta: &EditorMeta,
-    params: EditorParams,
-    result: Value,
+    meta: EditorMeta,
+    params: PositionParams,
+    result: Option<SignatureHelp>,
     ctx: &mut Context,
 ) {
-    let params = PositionParams::deserialize(params).expect("Failed to parse params");
-    let result: Option<SignatureHelp> =
-        serde_json::from_value(result).expect("Failed to parse signature help response");
     if let Some(result) = result {
         let active_signature = result.active_signature.unwrap_or(0);
         if let Some(active_signature) = result.signatures.get(active_signature as usize) {

--- a/src/text_sync.rs
+++ b/src/text_sync.rs
@@ -1,12 +1,12 @@
 use crate::context::*;
 use crate::types::*;
-use lsp_types::notification::Notification;
+use lsp_types::notification::*;
 use lsp_types::*;
 use ropey::Rope;
 use serde::Deserialize;
 use url::Url;
 
-pub fn text_document_did_open(meta: &EditorMeta, params: EditorParams, ctx: &mut Context) {
+pub fn text_document_did_open(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
     let params = TextDocumentDidOpenParams::deserialize(params);
     if params.is_err() {
         error!("Params should follow TextDocumentDidOpenParams structure");
@@ -27,10 +27,10 @@ pub fn text_document_did_open(meta: &EditorMeta, params: EditorParams, ctx: &mut
         text: Rope::from_str(&params.text_document.text),
     };
     ctx.documents.insert(meta.buffile.clone(), document);
-    ctx.notify(notification::DidOpenTextDocument::METHOD.into(), params);
+    ctx.notify::<DidOpenTextDocument>(params);
 }
 
-pub fn text_document_did_change(meta: &EditorMeta, params: EditorParams, ctx: &mut Context) {
+pub fn text_document_did_change(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
     let params = TextDocumentDidChangeParams::deserialize(params);
     if params.is_err() {
         error!("Params should follow TextDocumentDidChangeParams structure");
@@ -64,22 +64,22 @@ pub fn text_document_did_change(meta: &EditorMeta, params: EditorParams, ctx: &m
             text: params.draft,
         }],
     };
-    ctx.notify(notification::DidChangeTextDocument::METHOD.into(), params);
+    ctx.notify::<DidChangeTextDocument>(params);
 }
 
-pub fn text_document_did_close(meta: &EditorMeta, ctx: &mut Context) {
+pub fn text_document_did_close(meta: EditorMeta, ctx: &mut Context) {
     ctx.documents.remove(&meta.buffile);
     let uri = Url::from_file_path(&meta.buffile).unwrap();
     let params = DidCloseTextDocumentParams {
         text_document: TextDocumentIdentifier { uri },
     };
-    ctx.notify(notification::DidCloseTextDocument::METHOD.into(), params);
+    ctx.notify::<DidCloseTextDocument>(params);
 }
 
-pub fn text_document_did_save(meta: &EditorMeta, ctx: &mut Context) {
+pub fn text_document_did_save(meta: EditorMeta, ctx: &mut Context) {
     let uri = Url::from_file_path(&meta.buffile).unwrap();
     let params = DidSaveTextDocumentParams {
         text_document: TextDocumentIdentifier { uri },
     };
-    ctx.notify(notification::DidSaveTextDocument::METHOD.into(), params);
+    ctx.notify::<DidSaveTextDocument>(params);
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,4 @@
 use jsonrpc_core::{Call, Output, Params};
-use lsp_types::*;
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -172,20 +171,6 @@ where
 
         Ok(params)
     }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum ReferencesResponse {
-    None,
-    Array(Vec<Location>),
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum TextEditResponse {
-    None,
-    Array(Vec<TextEdit>),
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Changes ctx.call and ctx.notify to take the request type as a generic parameter, which simplifies calling and allows automatic parsing of the response type, and also eliminated the need for dispatch_server_response.

Created types to represent CCLS requests.

Also, EditorMeta was being passed by reference and then cloned frequently even though the caller had no need for it anymore. Changed to move instead and was able to remove lots of clone()s.

This is related to #110 but does not complete it.