### PR TITLE
Avoid unnecessary cloning

### DIFF
--- a/src/language_features/ccls.rs
+++ b/src/language_features/ccls.rs
@@ -37,13 +37,13 @@ impl Request for NavigateRequest {
 }
 
 pub fn navigate(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    let req_params = KakouneNavigateParams::deserialize(params.clone()).unwrap();
+    let params = KakouneNavigateParams::deserialize(params).unwrap();
     let req_params = NavigateParams {
         text_document: TextDocumentIdentifier {
             uri: Url::from_file_path(&meta.buffile).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &req_params.position, ctx).unwrap(),
-        direction: req_params.direction,
+        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
+        direction: params.direction,
     };
     ctx.call::<NavigateRequest, _>(
         meta,
@@ -87,12 +87,12 @@ impl Request for VarsRequest {
 }
 
 pub fn vars(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    let req_params = PositionParams::deserialize(params.clone()).unwrap();
+    let params = PositionParams::deserialize(params).unwrap();
     let req_params = VarsParams {
         text_document: TextDocumentIdentifier {
             uri: Url::from_file_path(&meta.buffile).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &req_params.position, ctx).unwrap(),
+        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
     };
     ctx.call::<VarsRequest, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
         references::editor_references(meta, result, ctx)
@@ -126,14 +126,14 @@ impl Request for InheritanceRequest {
 }
 
 pub fn inheritance(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    let req_params = KakouneInheritanceParams::deserialize(params.clone()).unwrap();
+    let params = KakouneInheritanceParams::deserialize(params).unwrap();
     let req_params = InheritanceParams {
         text_document: TextDocumentIdentifier {
             uri: Url::from_file_path(&meta.buffile).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &req_params.position, ctx).unwrap(),
-        levels: req_params.levels,
-        derived: req_params.derived,
+        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
+        levels: params.levels,
+        derived: params.derived,
     };
     ctx.call::<InheritanceRequest, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
         references::editor_references(meta, result, ctx)
@@ -165,13 +165,13 @@ impl Request for CallRequest {
 }
 
 pub fn call(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    let req_params = KakouneCallParams::deserialize(params.clone()).unwrap();
+    let params = KakouneCallParams::deserialize(params).unwrap();
     let req_params = CallParams {
         text_document: TextDocumentIdentifier {
             uri: Url::from_file_path(&meta.buffile).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &req_params.position, ctx).unwrap(),
-        callee: req_params.callee,
+        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
+        callee: params.callee,
     };
     ctx.call::<CallRequest, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
         references::editor_references(meta, result, ctx)
@@ -203,13 +203,13 @@ impl Request for MemberRequest {
 }
 
 pub fn member(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    let req_params = KakouneMemberParams::deserialize(params.clone()).unwrap();
+    let params = KakouneMemberParams::deserialize(params).unwrap();
     let req_params = MemberParams {
         text_document: TextDocumentIdentifier {
             uri: Url::from_file_path(&meta.buffile).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &req_params.position, ctx).unwrap(),
-        kind: req_params.kind,
+        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
+        kind: params.kind,
     };
     ctx.call::<MemberRequest, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
         references::editor_references(meta, result, ctx)

--- a/src/language_features/completion.rs
+++ b/src/language_features/completion.rs
@@ -78,5 +78,5 @@ pub fn editor_completion(
         "set window lsp_completions {}.{}@{} {}\n",
         p.line, params.completion.offset, meta.version, items
     );
-    ctx.exec(meta.clone(), command);
+    ctx.exec(meta, command);
 }

--- a/src/language_features/definition.rs
+++ b/src/language_features/definition.rs
@@ -7,12 +7,12 @@ use serde::Deserialize;
 use url::Url;
 
 pub fn text_document_definition(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    let req_params = PositionParams::deserialize(params.clone()).unwrap();
+    let params = PositionParams::deserialize(params).unwrap();
     let req_params = TextDocumentPositionParams {
         text_document: TextDocumentIdentifier {
             uri: Url::from_file_path(&meta.buffile).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &req_params.position, ctx).unwrap(),
+        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
     };
     ctx.call::<GotoDefinition, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
         editor_definition(meta, result, ctx)
@@ -29,6 +29,6 @@ pub fn editor_definition(
         let filename = path.to_str().unwrap();
         let p = get_kakoune_position(filename, &location.range.start, ctx).unwrap();
         let command = format!("edit {} {} {}", editor_quote(filename), p.line, p.column);
-        ctx.exec(meta.clone(), command);
+        ctx.exec(meta, command);
     };
 }

--- a/src/language_features/formatting.rs
+++ b/src/language_features/formatting.rs
@@ -7,16 +7,13 @@ use serde::Deserialize;
 use url::Url;
 
 pub fn text_document_formatting(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    let options = FormattingOptions::deserialize(params.clone());
-    if options.is_err() {
-        error!("Params should follow FormattingOptions structure");
-    }
-    let options = options.unwrap();
+    let params = FormattingOptions::deserialize(params)
+        .expect("Params should follow FormattingOptions structure");
     let req_params = DocumentFormattingParams {
         text_document: TextDocumentIdentifier {
             uri: Url::from_file_path(&meta.buffile).unwrap(),
         },
-        options,
+        options: params,
     };
     ctx.call::<Formatting, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
         editor_formatting(meta, result, ctx)

--- a/src/language_features/references.rs
+++ b/src/language_features/references.rs
@@ -12,12 +12,12 @@ use std::io::BufReader;
 use url::Url;
 
 pub fn text_document_references(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    let req_params = PositionParams::deserialize(params.clone()).unwrap();
+    let params = PositionParams::deserialize(params).unwrap();
     let req_params = ReferenceParams {
         text_document: TextDocumentIdentifier {
             uri: Url::from_file_path(&meta.buffile).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &req_params.position, ctx).unwrap(),
+        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
         context: ReferenceContext {
             include_declaration: true,
         },
@@ -87,12 +87,12 @@ pub fn text_document_references_highlight(
     params: EditorParams,
     ctx: &mut Context,
 ) {
-    let req_params = PositionParams::deserialize(params.clone()).unwrap();
+    let params = PositionParams::deserialize(params).unwrap();
     let req_params = ReferenceParams {
         text_document: TextDocumentIdentifier {
             uri: Url::from_file_path(&meta.buffile).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &req_params.position, ctx).unwrap(),
+        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
         context: ReferenceContext {
             include_declaration: true,
         },

--- a/src/language_features/rename.rs
+++ b/src/language_features/rename.rs
@@ -8,13 +8,13 @@ use std::fs;
 use url::Url;
 
 pub fn text_document_rename(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    let options = TextDocumentRenameParams::deserialize(params.clone()).unwrap();
+    let params = TextDocumentRenameParams::deserialize(params).unwrap();
     let req_params = RenameParams {
         text_document: TextDocumentIdentifier {
             uri: Url::from_file_path(&meta.buffile).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &options.position, ctx).unwrap(),
-        new_name: options.new_name,
+        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
+        new_name: params.new_name,
     };
     ctx.call::<Rename, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
         editor_rename(meta, result, ctx)

--- a/src/language_features/signature_help.rs
+++ b/src/language_features/signature_help.rs
@@ -38,7 +38,7 @@ pub fn editor_signature_help(
                 params.position,
                 editor_quote(&contents)
             );
-            ctx.exec(meta.clone(), command);
+            ctx.exec(meta, command);
         }
     }
 }

--- a/src/project_root.rs
+++ b/src/project_root.rs
@@ -40,7 +40,6 @@ pub fn gather_env_roots(language: &str) -> HashSet<PathBuf> {
     let prefix = format!("KAK_LSP_PROJECT_ROOT_{}", language.to_uppercase());
     debug!("Searching for vars starting with {}", prefix);
     env::vars()
-        .into_iter()
         .filter(|(k, _v)| k.starts_with(&prefix))
         .map(|(_k, v)| PathBuf::from(v))
         .collect()

--- a/src/text_sync.rs
+++ b/src/text_sync.rs
@@ -7,12 +7,8 @@ use serde::Deserialize;
 use url::Url;
 
 pub fn text_document_did_open(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    let params = TextDocumentDidOpenParams::deserialize(params);
-    if params.is_err() {
-        error!("Params should follow TextDocumentDidOpenParams structure");
-        return;
-    }
-    let params = params.unwrap();
+    let params = TextDocumentDidOpenParams::deserialize(params)
+        .expect("Params should follow TextDocumentDidOpenParams structure");
     let language_id = ctx.language_id.clone();
     let params = DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
@@ -31,12 +27,8 @@ pub fn text_document_did_open(meta: EditorMeta, params: EditorParams, ctx: &mut 
 }
 
 pub fn text_document_did_change(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    let params = TextDocumentDidChangeParams::deserialize(params);
-    if params.is_err() {
-        error!("Params should follow TextDocumentDidChangeParams structure");
-        return;
-    }
-    let params = params.unwrap();
+    let params = TextDocumentDidChangeParams::deserialize(params)
+        .expect("Params should follow TextDocumentDidChangeParams structure");
     let uri = Url::from_file_path(&meta.buffile).unwrap();
     let version = meta.version;
     let old_version = ctx

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -86,13 +86,9 @@ pub fn did_change_configuration(params: EditorParams, ctx: &mut Context) {
 }
 
 pub fn workspace_symbol(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
-    let req_params = WorkspaceSymbolParams::deserialize(params);
-    if req_params.is_err() {
-        error!("Params should follow WorkspaceSymbolParams structure");
-        return;
-    }
-    let req_params = req_params.unwrap();
-    ctx.call::<WorkspaceSymbol, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
+    let params = WorkspaceSymbolParams::deserialize(params)
+        .expect("Params should follow WorkspaceSymbolParams structure");
+    ctx.call::<WorkspaceSymbol, _>(meta, params, move |ctx: &mut Context, meta, result| {
         editor_workspace_symbol(meta, result, ctx)
     });
 }


### PR DESCRIPTION
Also, trying to keep params separate from req_params. The name changing purpose was confusing.