### PR TITLE
CodeAction support

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -150,6 +150,38 @@ column    = %d
 ' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" ${kak_cursor_line} ${kak_cursor_column} | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
 }
 
+define-command lsp-code-actions -docstring "Request code actions for the main cursor position" %{
+    lsp-did-change
+    nop %sh{ (printf '
+session   = "%s"
+client    = "%s"
+buffile   = "%s"
+filetype  = "%s"
+version   = %d
+method    = "textDocument/codeAction"
+[params.position]
+line      = %d
+column    = %d
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" ${kak_cursor_line} ${kak_cursor_column} | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
+}
+
+
+define-command -hidden lsp-execute-command -params 2 -docstring "Execute a command" %{
+    lsp-did-change
+    nop %sh{ (printf '
+session   = "%s"
+client    = "%s"
+buffile   = "%s"
+filetype  = "%s"
+version   = %d
+method    = "workspace/executeCommand"
+[params]
+command = "%s"
+arguments = %s
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" "$1" "$2" | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
+}
+
+
 define-command lsp-references -docstring "Open buffer with symbol references" %{
     lsp-did-change
     nop %sh{ (printf '
@@ -870,6 +902,7 @@ define-command lsp -params 1.. -shell-script-candidates %{
 ### User mode ###
 
 declare-user-mode lsp
+map global lsp a '<esc>: lsp-code-actions<ret>'           -docstring 'show code actions for current position'
 map global lsp c '<esc>: lsp-capabilities<ret>'           -docstring 'show language server capabilities'
 map global lsp d '<esc>: lsp-definition<ret>'             -docstring 'go to definition'
 map global lsp e '<esc>: lsp-diagnostics<ret>'            -docstring 'list project errors and warnings'

--- a/src/general.rs
+++ b/src/general.rs
@@ -44,7 +44,7 @@ pub fn initialize(
                 code_action: Some(CodeActionCapability {
                     code_action_literal_support: Some(CodeActionLiteralSupport {
                         code_action_kind: CodeActionKindLiteralSupport {
-                            value_set: vec![
+                            value_set: [
                                 "quickfix",
                                 "refactor",
                                 "refactor.extract",
@@ -128,6 +128,17 @@ pub fn capabilities(meta: EditorMeta, ctx: &mut Context) {
                 features.push("lsp-rename")
             }
             _ => (),
+        }
+    }
+
+    if let Some(ref code_action_provider) = server_capabilities.code_action_provider {
+        match code_action_provider {
+            CodeActionProviderCapability::Simple(x) => {
+                if *x {
+                    features.push("lsp-code-actions");
+                }
+            }
+            CodeActionProviderCapability::Options(_) => features.push("lsp-code-actions"),
         }
     }
 

--- a/src/general.rs
+++ b/src/general.rs
@@ -41,6 +41,25 @@ pub fn initialize(
                     }),
                     ..CompletionCapability::default()
                 }),
+                code_action: Some(CodeActionCapability {
+                    code_action_literal_support: Some(CodeActionLiteralSupport {
+                        code_action_kind: CodeActionKindLiteralSupport {
+                            value_set: vec![
+                                "quickfix",
+                                "refactor",
+                                "refactor.extract",
+                                "refactor.inline",
+                                "refactor.rewrite",
+                                "source",
+                                "source.organizeImports",
+                            ]
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect(),
+                        },
+                    }),
+                    ..CodeActionCapability::default()
+                }),
                 ..TextDocumentClientCapabilities::default()
             }),
             experimental: None,

--- a/src/language_features/codeaction.rs
+++ b/src/language_features/codeaction.rs
@@ -1,0 +1,69 @@
+use crate::context::*;
+use crate::types::*;
+use crate::util::*;
+use itertools::Itertools;
+use lsp_types::request::*;
+use lsp_types::*;
+use serde::Deserialize;
+use url::Url;
+
+pub fn text_document_codeaction(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
+    let params =
+        PositionParams::deserialize(params).expect("Params should follow PositionParams structure");
+    let position = get_lsp_position(&meta.buffile, &params.position, ctx).unwrap();
+
+    let req_params = CodeActionParams {
+        text_document: TextDocumentIdentifier {
+            uri: Url::from_file_path(&meta.buffile).unwrap(),
+        },
+        range: Range {
+            start: position,
+            end: position,
+        },
+        context: CodeActionContext {
+            diagnostics: vec![], // TODO
+            only: None,
+        },
+    };
+    ctx.call::<CodeActionRequest, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
+        editor_code_actions(meta, result, ctx)
+    });
+}
+
+pub fn editor_code_actions(
+    meta: EditorMeta,
+    result: Option<CodeActionResponse>,
+    ctx: &mut Context,
+) {
+    let result = match result {
+        Some(result) => result,
+        None => return,
+    };
+    match result {
+        CodeActionResponse::Commands(cmds) => {
+            if cmds.is_empty() {
+                return;
+            }
+            for cmd in &cmds {
+                debug!("Command: {:?}", cmd);
+            }
+            let menu_args = cmds
+                .iter()
+                .map(|command| {
+                    let title = editor_quote(&command.title);
+                    let cmd = editor_quote(&command.command);
+                    let args = &serde_json::to_string(&command.arguments).unwrap();
+                    let args = editor_quote(&serde_json::to_string(&args).unwrap());
+                    let select_cmd = editor_quote(&format!("lsp-execute-command {} {}", cmd, args));
+                    format!("{} {}", title, select_cmd)
+                })
+                .join(" ");
+            ctx.exec(meta, format!("menu {}", menu_args));
+        }
+        CodeActionResponse::Actions(actions) => {
+            for action in actions {
+                debug!("Action: {:?}", action);
+            }
+        }
+    }
+}

--- a/src/language_features/codeaction.rs
+++ b/src/language_features/codeaction.rs
@@ -42,6 +42,7 @@ pub fn editor_code_actions(
     match result {
         CodeActionResponse::Commands(cmds) => {
             if cmds.is_empty() {
+                ctx.exec(meta, format!("lsp-show-error 'No actions available'"));
                 return;
             }
             for cmd in &cmds {
@@ -52,6 +53,8 @@ pub fn editor_code_actions(
                 .map(|command| {
                     let title = editor_quote(&command.title);
                     let cmd = editor_quote(&command.command);
+                    // Double JSON serialization is performed to prevent parsing args as a TOML
+                    // structure when they are passed back via lsp-execute-command.
                     let args = &serde_json::to_string(&command.arguments).unwrap();
                     let args = editor_quote(&serde_json::to_string(&args).unwrap());
                     let select_cmd = editor_quote(&format!("lsp-execute-command {} {}", cmd, args));

--- a/src/language_features/mod.rs
+++ b/src/language_features/mod.rs
@@ -1,4 +1,5 @@
 pub mod ccls;
+pub mod codeaction;
 pub mod completion;
 pub mod cquery;
 pub mod definition;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -107,7 +107,7 @@ pub fn editor_workspace_symbol(
     let command = format!(
         "lsp-show-workspace-symbol {} {}",
         editor_quote(&ctx.root_path),
-        editor_quote(&editor_quote(&content)),
+        editor_quote(&content),
     );
     ctx.exec(meta, command);
 }


### PR DESCRIPTION
Enables basic support for code actions. I haven't tested this extensively, but it is enough to allow RLS's "Deglob Imports" action to work correctly.

In the future, I'd like to make it possible to show the number of available code actions in the modeline, maybe by setting a list option instead of immediately executing the menu command?