### PR TITLE
Add Nim support

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -96,3 +96,8 @@ args = ["--stdio"]
 
 [language.php.initialization_options]
 storagePath = "/tmp/intelephense"
+
+[language.nim]
+filetypes = ["nim"]
+roots = ["*.nimble", ".git"]
+command = "nimlsp"


### PR DESCRIPTION
Nim project is defined by the file with `.nimble` extension. I suppose i cannot add a substring as valid root?