### PR TITLE
Use Box<FnOnce>, stabilized in 1.35.0

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -112,7 +112,7 @@ pub fn start(
                     ServerMessage::Response(output) => {
                         match output {
                             Output::Success(success) => {
-                                if let Some((meta, _, mut callback)) = ctx.response_waitlist.remove(&success.id) {
+                                if let Some((meta, _, callback)) = ctx.response_waitlist.remove(&success.id) {
                                   callback(&mut ctx, meta, success.result);
                                 } else {
                                     error!("Id {:?} is not in waitlist!", success.id);


### PR DESCRIPTION
This removes code working around the lack of `Box<FnOnce>`!

If kak-lsp previously had a minimum supported rust version, this raises that to 1.35.0. Understandable if this isn't wanted because of that. If that's fine, this should be a pretty small change.