### PR TITLE
Insert before the cursor for all text edits

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -688,19 +688,6 @@ define-command -hidden lsp-show-message -params 2 -docstring %{
     info %arg{2}
 }
 
-define-command -hidden lsp-insert-after-selection -params 1 -docstring %{
-    Insert content after current selections while keeping cursor intact.
-    It is used to apply text edits from language server.
-} %{
-    declare-option -hidden str lsp_text_edit_tmp %sh{ mktemp }
-    declare-option -hidden str lsp_text_edit_content %arg{1}
-    execute-keys %sh{
-        printf "%s" "$kak_opt_lsp_text_edit_content" > $kak_opt_lsp_text_edit_tmp
-        printf "<a-!>cat %s<ret>" $kak_opt_lsp_text_edit_tmp
-    }
-    nop %sh{ rm $kak_opt_lsp_text_edit_tmp }
-}
-
 define-command -hidden lsp-insert-before-selection -params 1 -docstring %{
     Insert content before current selections while keeping cursor intact.
     It is used to apply text edits from language server.

--- a/src/text_edit.rs
+++ b/src/text_edit.rs
@@ -196,7 +196,6 @@ pub fn apply_text_edits_to_buffer(
             )| {
                 let command = match command {
                     KakouneTextEditCommand::InsertBefore => "lsp-insert-before-selection",
-                    KakouneTextEditCommand::InsertAfter => "lsp-insert-after-selection",
                     KakouneTextEditCommand::Replace => "lsp-replace-selection",
                 };
                 let command = format!(
@@ -240,7 +239,6 @@ pub fn apply_text_edits_to_buffer(
 
 enum KakouneTextEditCommand {
     InsertBefore,
-    InsertAfter,
     Replace,
 }
 
@@ -258,14 +256,11 @@ fn lsp_text_edit_to_kakoune(
     let TextEdit { range, new_text } = text_edit;
     let Range { start, end } = range;
     let insert = start.line == end.line && start.character == end.character;
-    let bol_insert = insert && range.end.character == 0;
 
     let range = lsp_range_to_kakoune(range, text, offset_encoding);
 
-    let command = if bol_insert {
+    let command = if insert {
         KakouneTextEditCommand::InsertBefore
-    } else if insert {
-        KakouneTextEditCommand::InsertAfter
     } else {
         KakouneTextEditCommand::Replace
     };


### PR DESCRIPTION
Currently, text is isnerted before the cursor when at column 0 and after the cursor at other columns. This is not correct, though: it "skips" over the position between columns 1 and 2 (in Kakoune coordinates) and makes inserts that aren't at the beginning of a line off by 1. Text should instead always be inserted before the cursor in Kakoune, not just when at the beginning of the line.

As far as I can see, `KakouneTextEditCommand::InsertAfter` isn't needed at all: cursors in Kakoune can refer to the newline character (or end-of-file if there is no newline at the end of the file) of each line, so even if the LSP column is at the end of the line, the insert can still be represented as an insertion before the cursor in Kakoune. (I hence removed it and the corresponding `lsp-insert-after-selection` command.)

Here is an example of the current behavior of `lsp-format`:

With this buffer:
```
int main() {
    if (true) {
        return long_function_name(alongargumentname, anotherargument, "a string", 100000000);
    }
}
```

Calling `lsp-format` (with clangd) sends back an insert with a new line and some indentation results in this
```
int main() {
    if (true) {
        return long_function_name(a
                longargumentname, anotherargument, "a string", 100000000);
    }
}
```

With this PR, `lsp-format` results in this (the output from the `clang-format` command):
```
int main() {
    if (true) {
        return long_function_name(
                alongargumentname, anotherargument, "a string", 100000000);
    }
}
```