### PR TITLE
Pass buffer content using stdio instead of environment variables

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -69,12 +69,21 @@ define-command -hidden lsp-did-change -docstring "Notify language server about b
     evaluate-commands %sh{
         if [ $kak_opt_lsp_timestamp -eq $kak_timestamp ]; then
             echo "fail"
-        else
-            echo "evaluate-commands -draft -no-hooks %{set-option buffer lsp_timestamp %val{timestamp}; execute-keys '%'; set-option buffer lsp_draft %val{selection}}"
         fi
     }
-    nop %sh{ (
-lsp_draft=$(printf '%s.' "${kak_opt_lsp_draft}" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed "s/$(printf '\t')/\\\\t/g")
+    set-option buffer lsp_timestamp %val{timestamp}
+    evaluate-commands -save-regs '|' %{
+        set-register '|' %{
+# dump stdin synchronously
+# append a . to the end, otherwise the subshell strips trailing newlines
+lsp_draft=$(cat; printf '.')
+# and process it asynchronously
+(
+# replace \ with \\
+#         " with \"
+#     <tab> with \t
+lsp_draft=$(printf '%s' "$lsp_draft" | sed 's/\\/\\\\/g ; s/"/\\"/g ; s/'"$(printf '\t')"'/\\t/g')
+# remove the trailing . we added earlier
 lsp_draft=${lsp_draft%.}
 printf '
 session  = "%s"
@@ -86,7 +95,9 @@ method   = "textDocument/didChange"
 [params]
 draft    = """
 %s"""
-' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" "${lsp_draft}" | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null }
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" "${lsp_draft}" | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
+        execute-keys -draft '%<a-|><ret>'
+    }
 }}
 
 define-command -hidden lsp-completion -docstring "Request completions for the main cursor position" %{
@@ -339,12 +350,15 @@ define-command -hidden lsp-did-open %{
     evaluate-commands %sh{
         if [ $kak_opt_lsp_timestamp -eq $kak_timestamp ]; then
             echo "fail"
-        else
-            echo "evaluate-commands -draft -no-hooks %{set-option buffer lsp_timestamp %val{timestamp}; execute-keys '%'; set-option buffer lsp_draft %val{selection}}"
         fi
     }
-    nop %sh{ (
-lsp_draft=$(printf '%s.' "${kak_opt_lsp_draft}" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed "s/$(printf '\t')/\\\\t/g")
+    # see lsp-did-change
+    set-option buffer lsp_timestamp %val{timestamp}
+    evaluate-commands -save-regs '|' %{
+        set-register '|' %{
+lsp_draft=$(cat; printf '.')
+(
+lsp_draft=$(printf '%s' "$lsp_draft" | sed 's/\\/\\\\/g ; s/"/\\"/g ; s/'"$(printf '\t')"'/\\t/g')
 lsp_draft=${lsp_draft%.}
 printf '
 session  = "%s"
@@ -357,6 +371,8 @@ method   = "textDocument/didOpen"
 draft    = """
 %s"""
 ' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" "${lsp_draft}" | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
+        execute-keys -draft '%<a-|><ret>'
+    }
 }
 
 define-command -hidden lsp-did-close %{

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -347,11 +347,6 @@ method   = "capabilities"
 }
 
 define-command -hidden lsp-did-open %{
-    evaluate-commands %sh{
-        if [ $kak_opt_lsp_timestamp -eq $kak_timestamp ]; then
-            echo "fail"
-        fi
-    }
     # see lsp-did-change
     set-option buffer lsp_timestamp %val{timestamp}
     evaluate-commands -save-regs '|' %{

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -964,7 +964,7 @@ define-command -hidden lsp-enable -docstring "Default integration with kak-lsp" 
     }
 }
 
-define-command -hidden lsp-disable -docstring "Disable kak-lsp in the window scope" %{
+define-command -hidden lsp-disable -docstring "Disable kak-lsp" %{
     remove-highlighter global/cquery_semhl
     remove-highlighter global/lsp_references
     lsp-inline-diagnostics-disable global

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -57,7 +57,6 @@ declare-option -hidden completions lsp_completions
 declare-option -hidden range-specs lsp_errors
 declare-option -hidden line-specs lsp_error_lines
 declare-option -hidden range-specs cquery_semhl
-declare-option -hidden str lsp_draft
 declare-option -hidden int lsp_timestamp -1
 declare-option -hidden range-specs lsp_references
 


### PR DESCRIPTION
Fixes #245 

Other notable changes:
* lsp-did-change was not operating asynchronously, but lsp-did-open was. They are now both asynchronous
* the three chained sed calls have been merged into one (I think that should be portable? Would be nice if on macos could test, since afaik it has noticeable differences)

To test this, you can check that with a file bigger than 128kib, changing the buffer content causes both kak-lsp and the language server to use _some_ cpu. Before, it did not and kept idling.

However jumping to definitions was working before, even on files that big. It's not entirely clear to me what didChange is supposed to do, but it does not seem entirely necessary?