### PR TITLE
Replace bingo with gopls

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -74,7 +74,7 @@ args = ["--lsp"]
 [language.go]
 filetypes = ["go"]
 roots = ["Gopkg.toml", "go.mod", ".git", ".hg"]
-command = "bingo"
+command = "gopls"
 offset_encoding = "utf-8"
 
 [language.bash]


### PR DESCRIPTION
Bingo has been discontinued and go-langserver is very slow (at least on go.mod projects), the best drop-in replacement is gopls (https://github.com/golang/tools/tree/master/gopls).