### PR TITLE
eclipse.jdt.ls organize imports extension

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -601,6 +601,21 @@ column    = %d
 ' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" $kind ${kak_cursor_line} ${kak_cursor_column} | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
 }
 
+# eclipse.jdt.ls Extension
+#
+define-command ejdtls-organize-imports -docstring "ejdtls-organize-imports: Organize imports." %{
+    lsp-did-change
+    nop %sh{ (printf '
+session   = "%s"
+client    = "%s"
+buffile   = "%s"
+filetype  = "%s"
+version   = %d
+method    = "eclipse.jdt.ls/organizeImports"
+[params]
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
+}
+
 ### Response handling ###
 
 # Feel free to override these commands in your config if you need to customise response handling.

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -16,7 +16,7 @@ use lsp_types::*;
 /// Start controller.
 ///
 /// Controller spawns language server for the given language and project root (passed as `route`).
-/// Then it takes care of dispatching editor requests to this language server and dispatching      
+/// Then it takes care of dispatching editor requests to this language server and dispatching
 /// responses back to editor.
 pub fn start(
     to_editor: Sender<EditorResponse>,
@@ -238,6 +238,11 @@ fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
         }
         ccls::MemberRequest::METHOD => {
             ccls::member(meta, params, ctx);
+        }
+
+        // eclipse.jdt.ls
+        "eclipse.jdt.ls/organizeImports" => {
+            eclipse_jdt_ls::organize_imports(meta, ctx);
         }
 
         _ => {

--- a/src/language_features/eclipse_jdt_ls.rs
+++ b/src/language_features/eclipse_jdt_ls.rs
@@ -1,0 +1,37 @@
+use lsp_types::request::ExecuteCommand;
+use crate::context::*;
+use crate::types::*;
+use crate::util::*;
+use lsp_types::*;
+
+pub fn organize_imports(meta: EditorMeta, ctx: &mut Context) {
+    let file_uri = Url::from_file_path(&meta.buffile).unwrap();
+
+    let req_params = ExecuteCommandParams {
+        command: "java.edit.organizeImports".to_string(),
+        arguments: vec![ serde_json::json!(file_uri.into_string()) ],
+    };
+    ctx.call::<ExecuteCommand, _>(
+        meta,
+        req_params,
+        move |ctx: &mut Context, meta, response| match response {
+            Some(response) => organize_imports_response(meta, serde_json::from_value(response).unwrap(), ctx),
+            None => return
+        }
+    );
+}
+
+pub fn organize_imports_response(meta: EditorMeta, result: Option<WorkspaceEdit>, ctx: &mut Context) {
+    let result = match result {
+        Some(result) => result,
+        None => return,
+    };
+
+    // Double JSON serialization is performed to prevent parsing args as a TOML
+    // structure when they are passed back via lsp-apply-workspace-edit.
+    let edit = &serde_json::to_string(&result).unwrap();
+    let edit = editor_quote(&serde_json::to_string(&edit).unwrap());
+    let select_cmd = format!("lsp-apply-workspace-edit {}", edit);
+
+    ctx.exec(meta, select_cmd);
+}

--- a/src/language_features/mod.rs
+++ b/src/language_features/mod.rs
@@ -1,4 +1,5 @@
 pub mod ccls;
+pub mod eclipse_jdt_ls;
 pub mod codeaction;
 pub mod completion;
 pub mod cquery;


### PR DESCRIPTION
Adds ejdtls-organize-imports command to invoke java.edit.organizeImports command of eclipse.jdt.ls.