### PR TITLE
Add LaTeX support

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -118,3 +118,8 @@ runtime = "node"
 elmPath = "elm"
 elmFormatPath = "elm-format"
 elmTestPath = "elm-test"
+
+[language.latex]
+filetypes = ["latex"]
+roots = [".git"]
+command = "texlab"


### PR DESCRIPTION
I couldn’t think of any sensible roots so I simply choose `.git`. Server is [texlab](https://github.com/latex-lsp/texlab).