### PR TITLE
Fix a quoting issue in lsp-find-error

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -865,7 +865,7 @@ Jump to the next or previous diagnostic error" %{
                 selection="$first"
             fi
         fi
-        printf "edit %b %b" "$kak_buffile" "$selection"
+        printf 'edit "%b" %b' "$kak_buffile" "$selection"
     }
 }
 


### PR DESCRIPTION
The missing quotes prevented the command from working if the file path contains spaces.