### PR TITLE
Update dart language server command

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -103,9 +103,11 @@ command = "bash-language-server"
 args = ["start"]
 
 [language.dart]
+# start shell to find path to dart analysis server source
 filetypes = ["dart"]
 roots = ["pubspec.yaml", ".git"]
-command = "dart_language_server"
+command = "sh"
+args = ["-c", "dart $(dirname $(which dart))/snapshots/analysis_server.dart.snapshot --lsp"]
 
 [language.d]
 filetypes = ["d", "di"]


### PR DESCRIPTION
We need to use a shell to find the correct path to the dart analysis
server source file. This should be in a known location relative to the
dart binary, regardless of whether the dart sdk was installed
stand-alone or part of the flutter toolkit. However the dart sdk and
binary location could be anywhere since it's commonly user installed
from source.