### PR TITLE
Support incremental semantic highlighting

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -607,6 +607,19 @@ cat ${pipe}
 rm -rf ${tmp}
 }}
 
+define-command lsp-update-semantic-highlighting -hidden %{
+    nop %sh{ (printf '
+session      = "%s"
+client       = "%s"
+buffile      = "%s"
+filetype     = "%s"
+version      = %d
+method       = "update-semantic-highlighting"
+[params]
+current = "%s"
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" "${kak_opt_lsp_semantic_highlighting}" | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null }
+}
+
 # CCLS Extension
 
 define-command ccls-navigate -docstring "Navigate C/C++/ObjectiveC file" -params 1 %{

--- a/src/context.rs
+++ b/src/context.rs
@@ -37,6 +37,7 @@ pub struct Context {
     pub documents: HashMap<String, Document>,
     pub offset_encoding: OffsetEncoding,
     pub semantic_highlighting_faces: Vec<String>,
+    pub semantic_highlighting_lines: HashMap<String, Vec<SemanticHighlightingInformation>>,
 }
 
 impl Context {
@@ -65,6 +66,7 @@ impl Context {
             documents: HashMap::default(),
             offset_encoding,
             semantic_highlighting_faces: Vec::new(),
+            semantic_highlighting_lines: HashMap::default(),
         }
     }
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -228,6 +228,9 @@ fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
         "semantic-scopes" => {
             semantic_highlighting::debug_scopes(meta, &mut ctx);
         }
+        "update-semantic-highlighting" => {
+            semantic_highlighting::editor_update(meta, params, &mut ctx);
+        }
 
         // CCLS
         ccls::NavigateRequest::METHOD => {


### PR DESCRIPTION
`clangd` now implements incremental highlighting, so i implemented it here.

It stores the updated lines in the context, and then calls `lsp-update-semantic-highlighting` in the editor, which sends the current semhl option to `kak-lsp`. This is then parsed, and any regions on updated lines are removed, and the new regions are added.

This is made a lot easier than one would think, because the semhl is sent from the server one line at a time, so no fancy overlap checking is requried.

Tested a little bit with clangd, it appears to work, and correctly removes old regions.