### PR TITLE
rust-analyzer inlay hints

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -262,7 +262,7 @@ That is, the keys of the `lsp_server_configuration` option are a `.`-delimited p
 Inlay hints are a feature supported by https://github.com/rust-analyzer/rust-analyzer[rust-analyzer], which show inferred types, parameter names in function calls, and the types of chained calls inline in the code. To enable support for it in kak-lsp, add the following to your `kakrc`:
 
 ----
-hook global BufCreate .*\.rs %{
+hook global WinSetOption filetype=rust %{
   hook window -group rust-inlay-hints BufReload .* rust-analyzer-inlay-hints
   hook window -group rust-inlay-hints InsertIdle .* rust-analyzer-inlay-hints
   hook -once -always window WinSetOption filetype=.* %{

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -257,6 +257,22 @@ set-option global lsp_server_configuration rust.clippy_preference="on"
 
 That is, the keys of the `lsp_server_configuration` option are a `.`-delimited path of JSON objects. For implementation reasons, the values use TOML serialisation rules rather than JSON rules, but they're pretty much the same thing for strings, numbers and booleans, which are the most common configuration types.
 
+== Inlay hints for rust-analyzer
+
+Inlay hints are a feature supported by https://github.com/rust-analyzer/rust-analyzer[rust-analyzer], which show inferred types, parameter names in function calls, and the types of chained calls inline in the code. To enable support for it in kak-lsp, add the following to your `kakrc`:
+
+----
+hook global BufCreate .*\.rs %{
+  hook window -group rust-inlay-hints BufReload .* rust-analyzer-inlay-hints
+  hook window -group rust-inlay-hints InsertIdle .* rust-analyzer-inlay-hints
+  hook -once -always window WinSetOption filetype=.* %{
+    remove-hooks window rust-inlay-hints
+  }
+}
+----
+
+You can change the face of the hints with `set-face global InlayHint <face>`.
+
 == Limitations
 
 === Encoding

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -13,6 +13,8 @@ set-face global DiagnosticWarning yellow
 set-face global LineFlagErrors red
 # Face for highlighting references.
 set-face global Reference MatchingChar
+# Face for inlay hints.
+set-face global InlayHint cyan+d
 
 # Options for tuning kak-lsp behaviour.
 

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -65,6 +65,7 @@ declare-option -hidden range-specs cquery_semhl
 declare-option -hidden int lsp_timestamp -1
 declare-option -hidden range-specs lsp_references
 declare-option -hidden range-specs lsp_semantic_highlighting
+declare-option -hidden range-specs rust_analyzer_inlay_hints
 
 ### Requests ###
 
@@ -757,6 +758,24 @@ method    = "eclipse.jdt.ls/organizeImports"
 ' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
 }
 
+# rust-analyzer extensions
+
+define-command rust-analyzer-inlay-hints -docstring "rust-analyzer-inlay-hints: Request inlay hints (rust-analyzer)" %{
+  lsp-did-change-and-then rust-analyzer-inlay-hints-request
+}
+
+define-command -hidden rust-analyzer-inlay-hints-request %{
+    nop %sh{ (printf '
+session   = "%s"
+client    = "%s"
+buffile   = "%s"
+filetype  = "%s"
+version   = %d
+method    = "rust-analyzer/inlayHints"
+[params]
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
+}
+
 ### Response handling ###
 
 # Feel free to override these commands in your config if you need to customise response handling.
@@ -1124,6 +1143,7 @@ define-command -hidden lsp-enable -docstring "Default integration with kak-lsp" 
     add-highlighter global/cquery_semhl ranges cquery_semhl
     add-highlighter global/lsp_references ranges lsp_references
     add-highlighter global/lsp_semantic_highlighting ranges lsp_semantic_highlighting
+    add-highlighter global/rust_analyzer_inlay_hints replace-ranges rust_analyzer_inlay_hints
     lsp-inline-diagnostics-enable global
     lsp-diagnostic-lines-enable global
 
@@ -1148,6 +1168,7 @@ define-command -hidden lsp-disable -docstring "Disable kak-lsp" %{
     remove-highlighter global/cquery_semhl
     remove-highlighter global/lsp_references
     remove-highlighter global/lsp_semantic_highlighting
+    remove-highlighter global/rust_analyzer_inlay_hints
     lsp-inline-diagnostics-disable global
     lsp-diagnostic-lines-disable global
     unmap global goto d '<esc>: lsp-definition<ret>' -docstring 'definition'
@@ -1165,6 +1186,7 @@ define-command lsp-enable-window -docstring "Default integration with kak-lsp in
     add-highlighter window/cquery_semhl ranges cquery_semhl
     add-highlighter window/lsp_references ranges lsp_references
     add-highlighter window/lsp_semantic_highlighting ranges lsp_semantic_highlighting
+    add-highlighter window/rust_analyzer_inlay_hints replace-ranges rust_analyzer_inlay_hints
 
     lsp-inline-diagnostics-enable window
     lsp-diagnostic-lines-enable window
@@ -1189,6 +1211,7 @@ define-command lsp-disable-window -docstring "Disable kak-lsp in the window scop
     remove-highlighter window/cquery_semhl
     remove-highlighter window/lsp_references
     remove-highlighter window/lsp_semantic_highlighting
+    remove-highlighter window/rust_analyzer_inlay_hints
     lsp-inline-diagnostics-disable window
     lsp-diagnostic-lines-disable window
     unmap window goto d '<esc>: lsp-definition<ret>'

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -264,6 +264,11 @@ fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
             eclipse_jdt_ls::organize_imports(meta, ctx);
         }
 
+        // rust-analyzer
+        rust_analyzer::InlayHints::METHOD => {
+            rust_analyzer::inlay_hints(meta, params, ctx);
+        }
+
         _ => {
             warn!("Unsupported method: {}", method);
         }

--- a/src/language_features/mod.rs
+++ b/src/language_features/mod.rs
@@ -10,5 +10,6 @@ pub mod hover;
 pub mod implementation;
 pub mod references;
 pub mod rename;
+pub mod rust_analyzer;
 pub mod semantic_highlighting;
 pub mod signature_help;

--- a/src/language_features/rust_analyzer.rs
+++ b/src/language_features/rust_analyzer.rs
@@ -1,0 +1,103 @@
+use crate::context::Context;
+use crate::position::lsp_range_to_kakoune;
+use crate::types::{EditorMeta, EditorParams, KakounePosition, KakouneRange};
+use crate::util::editor_quote;
+use lsp_types::request::Request;
+use lsp_types::{Range, TextDocumentIdentifier};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+pub enum InlayHints {}
+
+impl Request for InlayHints {
+    type Params = InlayHintsParams;
+    type Result = Vec<InlayHint>;
+    const METHOD: &'static str = "rust-analyzer/inlayHints";
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct InlayHintsParams {
+    pub text_document: TextDocumentIdentifier,
+}
+
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub enum InlayKind {
+    TypeHint,
+    ParameterHint,
+    ChainingHint,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct InlayHint {
+    pub range: Range,
+    pub kind: InlayKind,
+    pub label: String,
+}
+
+pub fn inlay_hints(meta: EditorMeta, _params: EditorParams, ctx: &mut Context) {
+    let req_params = InlayHintsParams {
+        text_document: TextDocumentIdentifier {
+            uri: Url::from_file_path(&meta.buffile).unwrap(),
+        },
+    };
+    ctx.call::<InlayHints, _>(meta, req_params, move |ctx, meta, response| {
+        inlay_hints_response(meta, response, ctx)
+    });
+}
+
+pub fn inlay_hints_response(meta: EditorMeta, inlay_hints: Vec<InlayHint>, ctx: &mut Context) {
+    let document = match ctx.documents.get(&meta.buffile) {
+        Some(document) => document,
+        None => return,
+    };
+    let ranges = inlay_hints
+        .into_iter()
+        .map(|InlayHint { range, kind, label }| {
+            let range = lsp_range_to_kakoune(&range, &document.text, &ctx.offset_encoding);
+            let label = label.replace("|", "\\|");
+            match kind {
+                InlayKind::TypeHint => {
+                    let pos = KakounePosition {
+                        line: range.end.line,
+                        column: range.end.column + 1,
+                    };
+                    let range = KakouneRange {
+                        start: pos.clone(),
+                        end: pos,
+                    };
+                    editor_quote(&format!("{}|{{default+di}}{{\\}}: {}", range, label))
+                }
+                InlayKind::ParameterHint => {
+                    let range = KakouneRange {
+                        start: range.start.clone(),
+                        end: range.start,
+                    };
+                    editor_quote(&format!("{}|{{default+di}}{{\\}}{}: ", range, label))
+                }
+                InlayKind::ChainingHint => {
+                    let pos = KakounePosition {
+                        line: range.end.line,
+                        column: range.end.column + 1,
+                    };
+                    let range = KakouneRange {
+                        start: pos.clone(),
+                        end: pos,
+                    };
+                    editor_quote(&format!("{}|{{default+di}}{{\\}} {}", range, label))
+                }
+            }
+        })
+        .collect::<Vec<String>>()
+        .join(" ");
+    let command = format!(
+        "set buffer rust_analyzer_inlay_hints {} {}",
+        meta.version, &ranges
+    );
+    let command = format!(
+        "eval -buffer {} {}",
+        editor_quote(&meta.buffile),
+        editor_quote(&command)
+    );
+    ctx.exec(meta, command.to_string())
+}

--- a/src/language_features/rust_analyzer.rs
+++ b/src/language_features/rust_analyzer.rs
@@ -66,14 +66,14 @@ pub fn inlay_hints_response(meta: EditorMeta, inlay_hints: Vec<InlayHint>, ctx: 
                         start: pos.clone(),
                         end: pos,
                     };
-                    editor_quote(&format!("{}|{{default+di}}{{\\}}: {}", range, label))
+                    editor_quote(&format!("{}|{{InlayHint}}{{\\}}: {}", range, label))
                 }
                 InlayKind::ParameterHint => {
                     let range = KakouneRange {
                         start: range.start.clone(),
                         end: range.start,
                     };
-                    editor_quote(&format!("{}|{{default+di}}{{\\}}{}: ", range, label))
+                    editor_quote(&format!("{}|{{InlayHint}}{{\\}}{}: ", range, label))
                 }
                 InlayKind::ChainingHint => {
                     let pos = KakounePosition {
@@ -84,7 +84,7 @@ pub fn inlay_hints_response(meta: EditorMeta, inlay_hints: Vec<InlayHint>, ctx: 
                         start: pos.clone(),
                         end: pos,
                     };
-                    editor_quote(&format!("{}|{{default+di}}{{\\}} {}", range, label))
+                    editor_quote(&format!("{}|{{InlayHint}}{{\\}} {}", range, label))
                 }
             }
         })

--- a/src/types.rs
+++ b/src/types.rs
@@ -167,7 +167,7 @@ where
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
 pub struct KakounePosition {
     pub line: u64,
     pub column: u64, // in bytes, not chars!!!
@@ -187,7 +187,11 @@ impl Display for KakounePosition {
 
 impl Display for KakouneRange {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{},{}", self.start, self.end)
+        if self.start == self.end {
+            write!(f, "{}+0", self.start)
+        } else {
+            write!(f, "{},{}", self.start, self.end)
+        }
     }
 }
 


### PR DESCRIPTION
![](https://tadeo.ca/u/YtMqt.png)

Requires https://github.com/mawww/kakoune/pull/3440.

To test:
- Use [rust-analyzer](https://github.com/rust-analyzer/rust-analyzer)
- `hook global NormalIdle .* rust-analyzer-inlay-hints`
- `hook global InsertIdle .* rust-analyzer-inlay-hints`
- Wait (rust-analyzer takes a while before it starts sending them)

I'm not sure what the best way to make these automatically requested is.