### PR TITLE
proposed Semantic Tokens support

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -273,6 +273,22 @@ hook global WinSetOption filetype=rust %{
 
 You can change the face of the hints with `set-face global InlayHint <face>`.
 
+== Semantic Tokens
+
+kak-lsp supports the semanticTokens feature for semantic highlighting. If the language server supports it, you can enable it with:
+
+----
+hook global WinSetOption filetype=<language> %{
+  hook window -group semantic-tokens BufReload .* lsp-semantic-tokens
+  hook window -group semantic-tokens InsertIdle .* lsp-semantic-tokens
+  hook -once -always window WinSetOption filetype=.* %{
+    remove-hooks window semantic-tokens
+  }
+}
+----
+
+The faces used for semantic tokens and modifiers can be modified in `kak-lsp.toml`, under the `semantic_tokens` and `semantic_modifiers` sections. The modifiers are used first if available, and then the main token type is used if no modifier face is specified.
+
 == Limitations
 
 === Encoding

--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -14,6 +14,24 @@ entity_name_type = "type"
 variable_other_enummember = "variable"
 entity_name_namespace = "module"
 
+# Semantic tokens support
+# See https://github.com/microsoft/vscode-languageserver-node/blob/8c8981eb4fb6adec27bf1bb5390a0f8f7df2899e/client/src/semanticTokens.proposed.ts#L288
+# for token/modifier types.
+
+[semantic_tokens]
+type = "type"
+variable = "variable"
+namespace = "module"
+function = "function"
+string = "string"
+keyword = "keyword"
+operator = "operator"
+comment = "comment"
+
+[semantic_modifiers]
+documentation = "documentation"
+readonly = "default+d"
+
 [server]
 # exit session if no requests were received during given period in seconds
 # works only in unix sockets mode (-s/--session)

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -67,6 +67,7 @@ declare-option -hidden range-specs cquery_semhl
 declare-option -hidden int lsp_timestamp -1
 declare-option -hidden range-specs lsp_references
 declare-option -hidden range-specs lsp_semantic_highlighting
+declare-option -hidden range-specs lsp_semantic_tokens
 declare-option -hidden range-specs rust_analyzer_inlay_hints
 
 ### Requests ###
@@ -778,6 +779,24 @@ method    = "rust-analyzer/inlayHints"
 ' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
 }
 
+# semantic tokens
+
+define-command lsp-semantic-tokens -docstring "semantic-tokens-update: Request semantic tokens" %{
+  lsp-did-change-and-then lsp-semantic-tokens-request
+}
+
+define-command -hidden lsp-semantic-tokens-request %{
+    nop %sh{ (printf '
+session   = "%s"
+client    = "%s"
+buffile   = "%s"
+filetype  = "%s"
+version   = %d
+method    = "textDocument/semanticTokens"
+[params]
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
+}
+
 ### Response handling ###
 
 # Feel free to override these commands in your config if you need to customise response handling.
@@ -1145,6 +1164,7 @@ define-command -hidden lsp-enable -docstring "Default integration with kak-lsp" 
     add-highlighter global/cquery_semhl ranges cquery_semhl
     add-highlighter global/lsp_references ranges lsp_references
     add-highlighter global/lsp_semantic_highlighting ranges lsp_semantic_highlighting
+    add-highlighter global/lsp_semantic_tokens ranges lsp_semantic_tokens
     add-highlighter global/rust_analyzer_inlay_hints replace-ranges rust_analyzer_inlay_hints
     lsp-inline-diagnostics-enable global
     lsp-diagnostic-lines-enable global
@@ -1170,6 +1190,7 @@ define-command -hidden lsp-disable -docstring "Disable kak-lsp" %{
     remove-highlighter global/cquery_semhl
     remove-highlighter global/lsp_references
     remove-highlighter global/lsp_semantic_highlighting
+    remove-highlighter global/lsp_semantic_tokens
     remove-highlighter global/rust_analyzer_inlay_hints
     lsp-inline-diagnostics-disable global
     lsp-diagnostic-lines-disable global
@@ -1188,6 +1209,7 @@ define-command lsp-enable-window -docstring "Default integration with kak-lsp in
     add-highlighter window/cquery_semhl ranges cquery_semhl
     add-highlighter window/lsp_references ranges lsp_references
     add-highlighter window/lsp_semantic_highlighting ranges lsp_semantic_highlighting
+    add-highlighter global/lsp_semantic_tokens ranges lsp_semantic_tokens
     add-highlighter window/rust_analyzer_inlay_hints replace-ranges rust_analyzer_inlay_hints
 
     lsp-inline-diagnostics-enable window
@@ -1213,6 +1235,7 @@ define-command lsp-disable-window -docstring "Disable kak-lsp in the window scop
     remove-highlighter window/cquery_semhl
     remove-highlighter window/lsp_references
     remove-highlighter window/lsp_semantic_highlighting
+    remove-highlighter window/lsp_semantic_tokens
     remove-highlighter window/rust_analyzer_inlay_hints
     lsp-inline-diagnostics-disable window
     lsp-diagnostic-lines-disable window

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -241,6 +241,9 @@ fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
         "update-semantic-highlighting" => {
             semantic_highlighting::editor_update(meta, params, &mut ctx);
         }
+        request::SemanticTokensRequest::METHOD => {
+            semantic_tokens::tokens_request(meta, params, ctx);
+        }
 
         // CCLS
         ccls::NavigateRequest::METHOD => {

--- a/src/language_features/mod.rs
+++ b/src/language_features/mod.rs
@@ -12,4 +12,5 @@ pub mod references;
 pub mod rename;
 pub mod rust_analyzer;
 pub mod semantic_highlighting;
+pub mod semantic_tokens;
 pub mod signature_help;

--- a/src/language_features/semantic_tokens.rs
+++ b/src/language_features/semantic_tokens.rs
@@ -1,0 +1,90 @@
+use crate::context::Context;
+use crate::position::lsp_range_to_kakoune;
+use crate::types::{EditorMeta, EditorParams};
+use crate::util::editor_quote;
+use lsp_types::request::SemanticTokensRequest;
+use lsp_types::{
+    Position, Range, SemanticToken, SemanticTokensOptions, SemanticTokensParams,
+    SemanticTokensRegistrationOptions, SemanticTokensResult, SemanticTokensServerCapabilities::*,
+    TextDocumentIdentifier,
+};
+use url::Url;
+
+pub fn tokens_request(meta: EditorMeta, _params: EditorParams, ctx: &mut Context) {
+    let req_params = SemanticTokensParams {
+        partial_result_params: Default::default(),
+        text_document: TextDocumentIdentifier {
+            uri: Url::from_file_path(&meta.buffile).unwrap(),
+        },
+        work_done_progress_params: Default::default(),
+    };
+    ctx.call::<SemanticTokensRequest, _>(meta, req_params, move |ctx, meta, response| {
+        if let Some(response) = response {
+            tokens_response(meta, response, ctx);
+        }
+    });
+}
+
+pub fn tokens_response(meta: EditorMeta, tokens: SemanticTokensResult, ctx: &mut Context) {
+    let legend = match ctx.capabilities.as_ref().unwrap().semantic_tokens_provider {
+        Some(SemanticTokensOptions(SemanticTokensOptions { ref legend, .. }))
+        | Some(SemanticTokensRegistrationOptions(SemanticTokensRegistrationOptions {
+            semantic_tokens_options: SemanticTokensOptions { ref legend, .. },
+            ..
+        })) => legend,
+        None => return,
+    };
+    let document = match ctx.documents.get(&meta.buffile) {
+        Some(document) => document,
+        None => return,
+    };
+    let tokens = match tokens {
+        SemanticTokensResult::Tokens(tokens) => tokens.data,
+        SemanticTokensResult::Partial(partial) => partial.data,
+    };
+    let mut line = 0;
+    let mut start = 0;
+    let ranges = tokens
+        .into_iter()
+        .filter_map(
+            |SemanticToken {
+                 delta_line,
+                 delta_start,
+                 length,
+                 token_type,
+                 token_modifiers_bitset,
+             }| {
+                if delta_line != 0 {
+                    line += delta_line;
+                    start = delta_start;
+                } else {
+                    start += delta_start;
+                }
+                let range = Range {
+                    start: Position::new(line.into(), start.into()),
+                    end: Position::new(line.into(), (start + length).into()),
+                };
+                let range = lsp_range_to_kakoune(&range, &document.text, &ctx.offset_encoding);
+                let token = &legend.token_types[token_type as usize];
+                (0..32)
+                    .filter(|bit| ((token_modifiers_bitset >> bit) & 1) == 1)
+                    .map(|bit| &legend.token_modifiers[bit as usize])
+                    .filter_map(|token| ctx.config.semantic_token_modifiers.get(token.as_str()))
+                    .chain(ctx.config.semantic_tokens.get(token.as_str()))
+                    .next()
+                    .map(|face| format!("{}|{}", range, face))
+            },
+        )
+        .collect::<Vec<String>>()
+        .join(" ");
+    let command = format!(
+        "set buffer lsp_semantic_tokens {} {}",
+        meta.version, &ranges
+    );
+    let command = format!(
+        "eval -buffer {} {}",
+        editor_quote(&meta.buffile),
+        editor_quote(&command)
+    );
+    ctx.exec(meta, command.to_string())
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,6 +21,10 @@ pub struct Config {
     pub snippet_support: bool,
     #[serde(default)]
     pub semantic_scopes: HashMap<String, String>,
+    #[serde(default)]
+    pub semantic_tokens: HashMap<String, String>,
+    #[serde(default)]
+    pub semantic_token_modifiers: HashMap<String, String>,
 }
 
 #[derive(Clone, Deserialize, Debug)]


### PR DESCRIPTION
The successor to the previous proposed semantic highlighting API.

Tested with rust-analyzer, I think clangd also has support.

Test with `:lsp-semantic-tokens`. Like my other PR, I'm not sure the right way to run this automatically is.