### PR TITLE
Inlay diagnostics support

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -291,6 +291,14 @@ hook global WinSetOption filetype=<language> %{
 
 The faces used for semantic tokens and modifiers can be modified in `kak-lsp.toml`, under the `semantic_tokens` and `semantic_modifiers` sections. The modifiers are used first if available, and then the main token type is used if no modifier face is specified.
 
+== Inlay Diagnostics
+
+kak-lsp supports showing diagnostics inline after their respective line, but this behaviour can be somewhat buggy and must be enabled explicitly:
+
+---
+lsp-inlay-diagnostics-enable global
+---
+
 == Limitations
 
 === Encoding

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -69,6 +69,7 @@ declare-option -hidden range-specs lsp_references
 declare-option -hidden range-specs lsp_semantic_highlighting
 declare-option -hidden range-specs lsp_semantic_tokens
 declare-option -hidden range-specs rust_analyzer_inlay_hints
+declare-option -hidden range-specs lsp_diagnostics
 
 ### Requests ###
 
@@ -1083,6 +1084,14 @@ define-command lsp-diagnostic-lines-enable -params 1 -docstring "lsp-diagnostic-
 
 define-command lsp-diagnostic-lines-disable -params 1 -docstring "lsp-diagnostic-lines-disable <scope>: Hide flags on lines with diagnostics in <scope>"  %{
     remove-highlighter "%arg{1}/lsp_error_lines"
+}
+
+define-command lsp-inlay-diagnostics-enable -params 1 -docstring "lsp-inlay-diagnostics-enable <scope>: Enable inlay diagnostics highlighting for <scope>" %{
+    add-highlighter "%arg{1}/lsp_diagnostics" replace-ranges lsp_diagnostics
+}
+
+define-command lsp-inlay-diagnostics-disable -params 1 -docstring "lsp-inlay-diagnostics-disable <scope>: Disable inlay diagnostics highlighting for <scope>"  %{
+    remove-highlighter "%arg{1}/lsp_diagnostics"
 }
 
 define-command lsp-auto-hover-enable -docstring "Enable auto-requesting hover info for current position" %{

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -57,6 +57,28 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
             )
         })
         .join(" ");
+    let diagnostic_ranges = diagnostics
+        .iter()
+        .map(|x| {
+            let face = match x.severity {
+                Some(DiagnosticSeverity::Error) => "DiagnosticError",
+                _ => "DiagnosticWarning",
+            };
+            // Pretend the language server sent us the diagnostic past the end of line
+            let range = Range {
+                start: Position {
+                    line: x.range.end.line,
+                    character: u64::MAX,
+                },
+                end: Position {
+                    line: x.range.end.line,
+                    character: u64::MAX,
+                },
+            };
+            let range = lsp_range_to_kakoune(&range, &document.text, &ctx.offset_encoding);
+            editor_quote(&format!("{}|{{{}}}{{\\}}{}", range, face, x.message))
+        })
+        .join(" ");
     // Always show a space on line one if no other highlighter is there,
     // to make sure the column always has the right width
     // Also wrap it in another eval and quotes, to make sure the %opt[] tags are expanded
@@ -64,8 +86,16 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
         "set buffer lsp_diagnostic_error_count {}
          set buffer lsp_diagnostic_warning_count {}
          set buffer lsp_errors {} {}
-         eval \"set buffer lsp_error_lines {} {} '0| '\"",
-        error_count, warning_count, version, ranges, version, line_flags
+         eval \"set buffer lsp_error_lines {} {} '0| '\"
+         eval \"set buffer lsp_diagnostics {} {}\"",
+        error_count,
+        warning_count,
+        version,
+        ranges,
+        version,
+        line_flags,
+        version,
+        diagnostic_ranges,
     );
     let command = format!(
         "

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -59,7 +59,8 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
         .join(" ");
     let diagnostic_ranges = diagnostics
         .iter()
-        .map(|x| {
+        .enumerate()
+        .map(|(i, x)| {
             let face = match x.severity {
                 Some(DiagnosticSeverity::Error) => "DiagnosticError",
                 _ => "DiagnosticWarning",
@@ -76,7 +77,13 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
                 },
             };
             let range = lsp_range_to_kakoune(&range, &document.text, &ctx.offset_encoding);
-            editor_quote(&format!("{}|{{{}}}{{\\}}{}", range, face, x.message))
+            editor_quote(&format!(
+                "{}|{{{}}}{{\\}}{}{}",
+                range,
+                face,
+                if i == 0 { "" } else { ", " }, // separate all but the first diagnostic on the same line
+                x.message
+            ))
         })
         .join(" ");
     // Always show a space on line one if no other highlighter is there,


### PR DESCRIPTION
This PR adds "inlay diagnostics" (because the name "inline diagnostics" is already taken):

It works well sometimes and saves time hovering over lines for errors:
![](https://tadeo.ca/u/P0EOe.png)
![](https://tadeo.ca/u/MEEkT.png)

But it's unfortunately also quite buggy:
![multiple at once](https://tadeo.ca/u/Fd6sX.png)
![hovering over the newline it's replacing](https://tadeo.ca/u/r8zSt.png)

I'm not sure if it should be merged, but I'm posting it here in case anyone has ideas on how to make it work better, or if anyone wants to use it anyway (I will), since hovering over lines is a big pain (in my opinion).