### PR TITLE
Fix completion errors

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1265,7 +1265,7 @@ face global SnippetsOtherPlaceholders black,yellow+F
 def -hidden lsp-snippets-insert-completion -params 2 %{ eval -save-regs "a" %{
     reg 'a' "%arg{1}"
     exec -draft "<a-;><a-/>%val[main_reg_a]<ret>d"
-    eval -draft -verbatim lsp-snippets-insert %arg{2}
+    eval -draft lsp-snippets-insert %arg{2}
     remove-hooks window lsp-post-completion
     hook -once -group lsp-post-completion window InsertCompletionHide .* %{
         try %{


### PR DESCRIPTION
Hi, I have recently started using this awesome tool with gopls language server.
When I start typing completion menu pops up but if I try to insert item it outputs following error:
```
1:1: 'eval' 7:271: 'lsp-snippets-insert-completion' 1:2: 'eval' 4:79: 'eval' unknown option '-verbatim'
```
I am using kak-lsp version 8.0.0 and gopls version 0.4.0.
Removing `-verbatim` resolves errors and completion works as expected. Tested on both release 8.0.0 and master.