### PR TITLE
Use textEdit completions that replace token left of cursor

### DIFF
--- a/src/language_features/completion.rs
+++ b/src/language_features/completion.rs
@@ -73,7 +73,21 @@ pub fn editor_completion(
                     .collect::<String>();
                 entry += &format!(" {{MenuInfo}}{:?}", k);
             }
-            let insert_text = &x.insert_text.unwrap_or(x.label);
+            // The generic textEdit property is not supported yet (#40).
+            // However, we can support simple text edits that only replace the token left of the
+            // cursor. Kakoune will do this very edit if we simply pass it the replacement string
+            // as completion.
+            let is_simple_text_edit = x.text_edit.as_ref().map_or(false, |text_edit|
+                text_edit.range.start.line + 1 == params.position.line &&
+                text_edit.range.start.character + 1 == params.completion.offset &&
+                text_edit.range.end.line + 1 == params.position.line &&
+                text_edit.range.end.character + 1 == params.position.column
+            );
+            let insert_text = &if is_simple_text_edit {
+                x.text_edit.unwrap().new_text
+            } else {
+                x.insert_text.unwrap_or(x.label)
+            };
             let do_snippet = ctx.config.snippet_support;
             let do_snippet = do_snippet
                 && x.insert_text_format


### PR DESCRIPTION
This is a targeted fix for the cases where Kakoune insertion would do
exactly the same as the text edit.
If the language server sends simple textEdit objects that replace
precisely the token left of the cursor, then we can just pass them to
Kakoune as normal completions. This is strictly better than using the
completion's label, because Kakoune's completion engine does exactly
what the text edit is supposed to do.

See below for an example that is not fixed by this commit. I believe
it makes sense to have this partial support until #40 is properly
implemented, because it seems safe and fixes what is arguably the most
common completion scenario: completing the suffix of a token.

Reproduce with this example C file using ccls. Cursor is `|`.

	void foobar(){}
	void main(){
		fo|	// Fixed:	Completion inserts foobar()
		fo|ba	// Not fixed:	Completion inserts foobar() -> void
	}

I thought about also changing the behavior for the "Not fixed" case,
where we could also just pass on the completion.
The result would be that Kakoune replaces "fo" with "foobar()",
ignoring the existing suffix, so we'd end up with "foobar()ba".
This is better than the labels here, but I'm not sure if it's
a good idea to knowingly leak this error.

Improves on #275