### PR TITLE
Request plain-text content for hover and signature information

### DIFF
--- a/src/general.rs
+++ b/src/general.rs
@@ -62,8 +62,19 @@ pub fn initialize(
                     }),
                     ..CodeActionCapability::default()
                 }),
+                hover: Some(HoverCapability {
+                    content_format: Some(vec![MarkupKind::PlainText]),
+                    ..HoverCapability::default()
+                }),
                 semantic_highlighting_capabilities: Some(SemanticHighlightingClientCapability {
                     semantic_highlighting: true,
+                }),
+                signature_help: Some(SignatureHelpCapability {
+                    signature_information: Some(SignatureInformationSettings {
+                        documentation_format: Some(vec![MarkupKind::PlainText]),
+                        parameter_information: None,
+                    }),
+                    ..SignatureHelpCapability::default()
                 }),
                 ..TextDocumentClientCapabilities::default()
             }),


### PR DESCRIPTION
This was missed two years ago, when fixed for the completion. This
ensures that e.g. gopls no longer tries to send us Markdown.

Overlooked for ... almost 2 years :) https://github.com/ul/kak-lsp/issues/69#issuecomment-404334258