### PR TITLE
doc: mention that lsp-references is mapped to gr by default

### DIFF
--- a/src/general.rs
+++ b/src/general.rs
@@ -127,7 +127,7 @@ pub fn capabilities(meta: EditorMeta, ctx: &mut Context) {
     }
 
     if server_capabilities.references_provider.unwrap_or(false) {
-        features.push("lsp-references");
+        features.push("lsp-references (mapped to `gr` by default)");
     }
 
     if server_capabilities


### PR DESCRIPTION
Hi

When executing `lsp-capabilities`, the mapping for `lsp-definition` appears in the infobox but the one for `lsp-references` is missing