### PR TITLE
Update default haskell config to use `hie-wrapper`

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -105,7 +105,9 @@ args = ["--init={\"cacheDirectory\":\"/tmp/cquery\",\"highlight\":{\"enabled\":t
 [language.haskell]
 filetypes = ["haskell"]
 roots = ["Setup.hs", "stack.yaml", "*.cabal"]
-command = "hie"
+# You might also be interested in the newer, but early stage, haskell-language-server
+# https://github.com/haskell/haskell-language-server
+command = "hie-wrapper"
 args = ["--lsp"]
 
 [language.go]


### PR DESCRIPTION
[haskell-ide-engine](https://github.com/haskell/haskell-ide-engine/) added `hie-wrapper` two years ago, to identify the right ghc version to use.