### PR TITLE
Rust 1.41.0 fixups

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -7,6 +7,7 @@ use jsonrpc_core::Params;
 use lsp_types::*;
 use std::collections::HashSet;
 use std::path::Path;
+use std::u64;
 
 pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
     let params: PublishDiagnosticsParams = params.parse().expect("Failed to parse params");

--- a/src/language_features/semantic_tokens.rs
+++ b/src/language_features/semantic_tokens.rs
@@ -67,7 +67,7 @@ pub fn tokens_response(meta: EditorMeta, tokens: SemanticTokensResult, ctx: &mut
                 let range = lsp_range_to_kakoune(&range, &document.text, &ctx.offset_encoding);
                 let token = &legend.token_types[token_type as usize];
                 (0..32)
-                    .filter(|bit| ((token_modifiers_bitset >> bit) & 1) == 1)
+                    .filter(|bit| ((token_modifiers_bitset >> bit) & 1u32) == 1u32)
                     .map(|bit| &legend.token_modifiers[bit as usize])
                     .filter_map(|token| ctx.config.semantic_token_modifiers.get(token.as_str()))
                     .chain(ctx.config.semantic_tokens.get(token.as_str()))


### PR DESCRIPTION
Ran `cargo test`. These fixups were needed for `master` to compile.
Not 100% sure why type inference didn't work on these literals.
Needed to use u64 to get access to u64::MAX.
