### PR TITLE
Add selection formatting

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -604,6 +604,38 @@ insertSpaces = %s
 ' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" "${kak_opt_tabstop}" "${kak_opt_lsp_insert_spaces}" | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null }
 }
 
+define-command lsp-range-formatting -docstring "Format selections" %{
+    lsp-did-change-and-then lsp-range-formatting-request
+}
+
+define-command -hidden lsp-range-formatting-request -docstring "Format selections" %{
+    nop %sh{
+for range in ${kak_selections_char_desc}; do
+    IFS=, read start end <<< $range
+    IFS=. read startline startcolumn <<< $start
+    IFS=. read endline endcolumn <<< $end
+
+    (printf '
+session      = "%s"
+client       = "%s"
+buffile      = "%s"
+filetype     = "%s"
+version      = %d
+method       = "textDocument/rangeFormatting"
+[params]
+tabSize      = %d
+insertSpaces = %s
+[range.start]
+line = %d
+character = %d
+[range.end]
+line = %d
+character = %d
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" "${kak_opt_tabstop}" "${kak_opt_lsp_insert_spaces}" $((startline - 1)) $((startcolumn - 1)) $((endline - 1)) $((endcolumn - 1)) | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null
+
+done
+}}
+
 define-command lsp-formatting-sync -docstring "Format document, blocking Kakoune session until done" %{
     lsp-did-change-and-then lsp-formatting-sync-request
 }
@@ -628,6 +660,43 @@ insertSpaces = %s
 ' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" ${pipe} "${kak_opt_tabstop}" "${kak_opt_lsp_insert_spaces}" | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null
 
 cat ${pipe}
+rm -rf ${tmp}
+}}
+
+define-command lsp-range-formatting-sync -docstring "Format selections, blocking Kakoune session until done" %{
+    eval -draft -itersel 'lsp-did-change-and-then lsp-range-formatting-sync-request'
+}
+
+define-command -hidden lsp-range-formatting-sync-request -docstring "Format selections, blocking Kakoune session until done" %{
+    evaluate-commands -no-hooks %sh{
+range=${kak_selection_desc}
+tmp=$(mktemp -q -d -t 'lsp-formatting.XXXXXX' 2>/dev/null || mktemp -q -d)
+pipe=${tmp}/fifo
+mkfifo ${pipe}
+IFS=, read start end <<< $range
+IFS=. read startline startcolumn <<< $start
+IFS=. read endline endcolumn <<< $end
+
+(printf '
+session      = "%s"
+client       = "%s"
+buffile      = "%s"
+filetype     = "%s"
+version      = %d
+fifo         = "%s"
+method       = "textDocument/rangeFormatting"
+[params]
+tabSize      = %d
+insertSpaces = %s
+[range.start]
+line = %d
+character = %d
+[range.end]
+line = %d
+character = %d
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" ${pipe} "${kak_opt_tabstop}" "${kak_opt_lsp_insert_spaces}" $((startline - 1)) $((startcolumn - 1)) $((endline - 1)) $((endcolumn - 1)) | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null
+
+cat ${pipe} | tee /tmp/pipe
 rm -rf ${tmp}
 }}
 
@@ -1173,6 +1242,7 @@ map global lsp p '<esc>: lsp-find-error --previous<ret>'  -docstring 'find previ
 map global lsp q '<esc>: lsp-exit<ret>'                   -docstring 'exit session'
 map global lsp y '<esc>: lsp-type-definition<ret>'        -docstring 'go to type definition'
 map global lsp <&> '<esc>: lsp-highlight-references<ret>' -docstring 'lsp-highlight-references'
+map global lsp = '<esc>: lsp-range-formatting<ret>'       -docstring 'format selections'
 
 ### Default integration ###
 

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -610,12 +610,22 @@ define-command lsp-range-formatting -docstring "Format selections" %{
 
 define-command -hidden lsp-range-formatting-request -docstring "Format selections" %{
     nop %sh{
-for range in ${kak_selections_char_desc}; do
+ranges_str="$(for range in ${kak_selections_char_desc}; do
     IFS=, read start end <<< $range
     IFS=. read startline startcolumn <<< $start
     IFS=. read endline endcolumn <<< $end
+    printf '
+[[ranges]]
+  [ranges.start]
+  line = %d
+  character = %d
+  [ranges.end]
+  line = %d
+  character = %d
+' $((startline - 1)) $((startcolumn - 1)) $((endline - 1)) $((endcolumn - 1))
+done)"
 
-    (printf '
+(printf '
 session      = "%s"
 client       = "%s"
 buffile      = "%s"
@@ -625,15 +635,8 @@ method       = "textDocument/rangeFormatting"
 [params]
 tabSize      = %d
 insertSpaces = %s
-[range.start]
-line = %d
-character = %d
-[range.end]
-line = %d
-character = %d
-' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" "${kak_opt_tabstop}" "${kak_opt_lsp_insert_spaces}" $((startline - 1)) $((startcolumn - 1)) $((endline - 1)) $((endcolumn - 1)) | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null
-
-done
+%s
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" "${kak_opt_tabstop}" "${kak_opt_lsp_insert_spaces}" "${ranges_str}" | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null
 }}
 
 define-command lsp-formatting-sync -docstring "Format document, blocking Kakoune session until done" %{
@@ -664,7 +667,7 @@ rm -rf ${tmp}
 }}
 
 define-command lsp-range-formatting-sync -docstring "Format selections, blocking Kakoune session until done" %{
-    eval -draft -itersel 'lsp-did-change-and-then lsp-range-formatting-sync-request'
+    lsp-did-change-and-then lsp-range-formatting-sync-request
 }
 
 define-command -hidden lsp-range-formatting-sync-request -docstring "Format selections, blocking Kakoune session until done" %{
@@ -673,9 +676,20 @@ range=${kak_selection_desc}
 tmp=$(mktemp -q -d -t 'lsp-formatting.XXXXXX' 2>/dev/null || mktemp -q -d)
 pipe=${tmp}/fifo
 mkfifo ${pipe}
-IFS=, read start end <<< $range
-IFS=. read startline startcolumn <<< $start
-IFS=. read endline endcolumn <<< $end
+ranges_str="$(for range in ${kak_selections_char_desc}; do
+    IFS=, read start end <<< $range
+    IFS=. read startline startcolumn <<< $start
+    IFS=. read endline endcolumn <<< $end
+    printf '
+[[ranges]]
+  [ranges.start]
+  line = %d
+  character = %d
+  [ranges.end]
+  line = %d
+  character = %d
+' $((startline - 1)) $((startcolumn - 1)) $((endline - 1)) $((endcolumn - 1))
+done)"
 
 (printf '
 session      = "%s"
@@ -688,13 +702,8 @@ method       = "textDocument/rangeFormatting"
 [params]
 tabSize      = %d
 insertSpaces = %s
-[range.start]
-line = %d
-character = %d
-[range.end]
-line = %d
-character = %d
-' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" ${pipe} "${kak_opt_tabstop}" "${kak_opt_lsp_insert_spaces}" $((startline - 1)) $((startcolumn - 1)) $((endline - 1)) $((endcolumn - 1)) | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null
+%s
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" ${pipe} "${kak_opt_tabstop}" "${kak_opt_lsp_insert_spaces}" "${ranges_str}" | ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null
 
 cat ${pipe} | tee /tmp/pipe
 rm -rf ${tmp}

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -175,7 +175,7 @@ fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
     let meta = request.meta;
     let params = request.params;
     let method: &str = &request.method;
-    let range: Option<Range> = request.range;
+    let ranges: Option<Vec<Range>> = request.ranges;
     match method {
         notification::DidOpenTextDocument::METHOD => {
             text_document_did_open(meta, params, &mut ctx);
@@ -231,7 +231,7 @@ fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
         request::Formatting::METHOD => {
             formatting::text_document_formatting(meta, params, &mut ctx);
         }
-        request::RangeFormatting::METHOD => match range {
+        request::RangeFormatting::METHOD => match ranges {
             Some(range) => range_formatting::text_document_range_formatting(meta, params, range, &mut ctx),
             None => warn!("No range provided to {}", method),
         }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -175,6 +175,7 @@ fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
     let meta = request.meta;
     let params = request.params;
     let method: &str = &request.method;
+    let range: Option<Range> = request.range;
     match method {
         notification::DidOpenTextDocument::METHOD => {
             text_document_did_open(meta, params, &mut ctx);
@@ -229,6 +230,10 @@ fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
         }
         request::Formatting::METHOD => {
             formatting::text_document_formatting(meta, params, &mut ctx);
+        }
+        request::RangeFormatting::METHOD => match range {
+            Some(range) => range_formatting::text_document_range_formatting(meta, params, range, &mut ctx),
+            None => warn!("No range provided to {}", method),
         }
         request::WorkspaceSymbol::METHOD => {
             workspace::workspace_symbol(meta, params, &mut ctx);

--- a/src/general.rs
+++ b/src/general.rs
@@ -305,6 +305,13 @@ pub fn capabilities(meta: EditorMeta, ctx: &mut Context) {
         features.push("lsp-formatting");
     }
 
+    if server_capabilities
+        .document_range_formatting_provider
+        .unwrap_or(false)
+    {
+        features.push("lsp-format-selection");
+    }
+
     if let Some(ref rename_provider) = server_capabilities.rename_provider {
         match rename_provider {
             RenameProviderCapability::Simple(true) | RenameProviderCapability::Options(_) => {

--- a/src/general.rs
+++ b/src/general.rs
@@ -309,7 +309,7 @@ pub fn capabilities(meta: EditorMeta, ctx: &mut Context) {
         .document_range_formatting_provider
         .unwrap_or(false)
     {
-        features.push("lsp-format-selection");
+        features.push("lsp-range-formatting");
     }
 
     if let Some(ref rename_provider) = server_capabilities.rename_provider {

--- a/src/language_features/mod.rs
+++ b/src/language_features/mod.rs
@@ -8,6 +8,7 @@ pub mod formatting;
 pub mod goto;
 pub mod highlights;
 pub mod hover;
+pub mod range_formatting;
 pub mod rename;
 pub mod rust_analyzer;
 pub mod semantic_highlighting;

--- a/src/language_features/range_formatting.rs
+++ b/src/language_features/range_formatting.rs
@@ -6,43 +6,35 @@ use lsp_types::*;
 use serde::Deserialize;
 use url::Url;
 
-pub fn text_document_range_formatting(meta: EditorMeta, params: EditorParams, range: Range, ctx: &mut Context) {
+pub fn text_document_range_formatting(meta: EditorMeta, params: EditorParams, ranges: Vec<Range>, ctx: &mut Context) {
     let params = FormattingOptions::deserialize(params)
         .expect("Params should follow FormattingOptions structure");
-    let req_params = DocumentRangeFormattingParams {
+    let req_params = ranges.into_iter().map(|range|
+      DocumentRangeFormattingParams {
         text_document: TextDocumentIdentifier {
             uri: Url::from_file_path(&meta.buffile).unwrap(),
         },
         range: range,
-        options: params,
+        options: params.clone(),
         work_done_progress_params: Default::default(),
-    };
-    ctx.call::<RangeFormatting, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
+    }).collect();
+    ctx.batch_call::<RangeFormatting, _>(meta, req_params, move |ctx: &mut Context, meta, results| {
+        let result = results.into_iter().flatten().flatten().collect();
         editor_range_formatting(meta, result, ctx)
     });
 }
 
-pub fn editor_range_formatting(meta: EditorMeta, result: Option<Vec<TextEdit>>, ctx: &mut Context) {
+pub fn editor_range_formatting(meta: EditorMeta, text_edits: Vec<TextEdit>, ctx: &mut Context) {
     let document = ctx.documents.get(&meta.buffile);
-    if document.is_none() {
+    if text_edits.len() == 0 {
         // Nothing to do, but sending command back to the editor is required to handle case when
         // editor is blocked waiting for response via fifo.
         ctx.exec(meta, "nop".to_string());
         return;
     }
     let document = document.unwrap();
-    match result {
-        None => {
-            // Nothing to do, but sending command back to the editor is required to handle case when
-            // editor is blocked waiting for response via fifo.
-            ctx.exec(meta, "nop".to_string());
-            return;
-        }
-        Some(text_edits) => {
-            ctx.exec(
-                meta,
-                apply_text_edits_to_buffer(None, &text_edits, &document.text, &ctx.offset_encoding),
-            );
-        }
-    }
+    ctx.exec(
+        meta,
+        apply_text_edits_to_buffer(None, &text_edits, &document.text, &ctx.offset_encoding),
+    );
 }

--- a/src/language_features/range_formatting.rs
+++ b/src/language_features/range_formatting.rs
@@ -1,0 +1,48 @@
+use crate::context::*;
+use crate::text_edit::apply_text_edits_to_buffer;
+use crate::types::*;
+use lsp_types::request::*;
+use lsp_types::*;
+use serde::Deserialize;
+use url::Url;
+
+pub fn text_document_range_formatting(meta: EditorMeta, params: EditorParams, range: Range, ctx: &mut Context) {
+    let params = FormattingOptions::deserialize(params)
+        .expect("Params should follow FormattingOptions structure");
+    let req_params = DocumentRangeFormattingParams {
+        text_document: TextDocumentIdentifier {
+            uri: Url::from_file_path(&meta.buffile).unwrap(),
+        },
+        range: range,
+        options: params,
+        work_done_progress_params: Default::default(),
+    };
+    ctx.call::<RangeFormatting, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
+        editor_range_formatting(meta, result, ctx)
+    });
+}
+
+pub fn editor_range_formatting(meta: EditorMeta, result: Option<Vec<TextEdit>>, ctx: &mut Context) {
+    let document = ctx.documents.get(&meta.buffile);
+    if document.is_none() {
+        // Nothing to do, but sending command back to the editor is required to handle case when
+        // editor is blocked waiting for response via fifo.
+        ctx.exec(meta, "nop".to_string());
+        return;
+    }
+    let document = document.unwrap();
+    match result {
+        None => {
+            // Nothing to do, but sending command back to the editor is required to handle case when
+            // editor is blocked waiting for response via fifo.
+            ctx.exec(meta, "nop".to_string());
+            return;
+        }
+        Some(text_edits) => {
+            ctx.exec(
+                meta,
+                apply_text_edits_to_buffer(None, &text_edits, &document.text, &ctx.offset_encoding),
+            );
+        }
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -176,7 +176,7 @@ fn stop_session(controllers: &mut Controllers) {
         },
         method: notification::Exit::METHOD.to_string(),
         params: toml::Value::Table(toml::value::Table::default()),
-        range: None,
+        ranges: None,
     };
     info!("Shutting down language servers and exiting");
     for (route, controller) in controllers.drain() {

--- a/src/session.rs
+++ b/src/session.rs
@@ -176,6 +176,7 @@ fn stop_session(controllers: &mut Controllers) {
         },
         method: notification::Exit::METHOD.to_string(),
         params: toml::Value::Table(toml::value::Table::default()),
+        range: None,
     };
     info!("Shutting down language servers and exiting");
     for (route, controller) in controllers.drain() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::io::Error;
 use toml;
+use lsp_types::Range;
 
 pub enum Void {}
 
@@ -80,6 +81,7 @@ pub struct EditorRequest {
     pub meta: EditorMeta,
     pub method: String,
     pub params: EditorParams,
+    pub range: Option<Range>,
 }
 
 #[derive(Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -81,7 +81,7 @@ pub struct EditorRequest {
     pub meta: EditorMeta,
     pub method: String,
     pub params: EditorParams,
-    pub range: Option<Range>,
+    pub ranges: Option<Vec<Range>>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Adds support for `textDocument/rangeFormatting`, which formats the current selections.

Tested with `haskell-language-server`.

~Because the `language-server-protocol` doesn't support batching, we're using one message per selection. This means we also get a history item per selection :shrug:.~