### PR TITLE
fix diagnostics in hover when lsp_hover_max_lines > 0

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -815,7 +815,7 @@ define-command -hidden lsp-show-hover -params 3 -docstring %{
     content="${content%"${content##*[![:space:]]}"}"
 
     if [ $kak_opt_lsp_hover_max_lines -gt 0 ]; then
-        content=$(printf %s "$2" | head -n $kak_opt_lsp_hover_max_lines)
+        content=$(printf %s "$content" | head -n $kak_opt_lsp_hover_max_lines)
     fi
 
     content=$(printf %s "$content" | sed s/\'/\'\'/g)


### PR DESCRIPTION
I noticed when I had set the lsp_hover_max_lines option my diagnostics in hover were not showing, this change fixed it for me.