### PR TITLE
Give preference to roots according to their position in configuration list

### DIFF
--- a/src/project_root.rs
+++ b/src/project_root.rs
@@ -13,14 +13,14 @@ pub fn find_project_root(language: &str, markers: &[String], path: &str) -> Stri
 }
 
 pub fn roots_by_marker(roots: &[String], path: &str) -> String {
-    let mut pwd = PathBuf::from(path);
-    while !pwd.is_dir() {
-        pwd.pop();
+    let mut src = PathBuf::from(path);
+    while !src.is_dir() {
+        src.pop();
     }
-    let src = pwd.to_str().unwrap().to_string();
 
-    loop {
-        for root in roots {
+    for root in roots {
+        let mut pwd = src.clone();
+        loop {
             // unwrap should be safe here because we walk up path previously converted from str
             let matches = glob(pwd.join(root).to_str().unwrap());
             if let Ok(mut m) = matches {
@@ -29,11 +29,12 @@ pub fn roots_by_marker(roots: &[String], path: &str) -> String {
                     return pwd.to_str().unwrap().to_string();
                 }
             }
-        }
-        if !pwd.pop() {
-            return src;
+            if !pwd.pop() {
+                break;
+            }
         }
     }
+    return src.to_str().unwrap().to_string();
 }
 
 pub fn gather_env_roots(language: &str) -> HashSet<PathBuf> {


### PR DESCRIPTION
Tweak the root finding logic to search for roots in order of their appearance in
the list.

This is useful when you have subprojects underneath your main project directory,
but would like to set the root to the parent project directory.

For example, we might have nested haskell subprojects like

```
.
├── project.cabal
├── hie.yaml
├── src
│  └── ...
├── subproject
│  ├── subproject.cabal
│  └── ...
└── ..
```

Even though there is a `subproject.cabal` file, we want to give preference to a
`hie.yaml` file which, if it exists, tells the language server exactly how to
load the project. This is not the case with a `*.cabal` file, where the language
server has to do some guesswork (which might fail).

With this patch, we can achieve the desired behaviour by setting the haskell
configuration roots as:

```yaml
[language.haskell]
roots = ["hie.yaml","stack.yaml","*.cabal","Setup.hs"]
```
