### PR TITLE
Fix inlay diagnostics for gopls

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -281,6 +281,8 @@ hook global WinSetOption filetype=rust %{
 
 You can change the face of the hints with `set-face global InlayHint <face>`.
 
+Note that this requires you to build Kakoune from source as the feature that allows this is not yet in a release.
+
 == Semantic Tokens
 
 kak-lsp supports the semanticTokens feature for semantic highlighting. If the language server supports it, you can enable it with:
@@ -305,6 +307,8 @@ kak-lsp supports showing diagnostics inline after their respective line, but thi
 ----
 lsp-inlay-diagnostics-enable global
 ----
+
+Note that this requires you to build Kakoune from source as the feature that allows this is not yet in a release.
 
 == Limitations
 

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -68,18 +68,10 @@ pub fn publish_diagnostics(params: Params, ctx: &mut Context) {
             };
             // Pretend the language server sent us the diagnostic past the end of line
             let line = x.range.end.line;
-            let range = Range {
-                start: Position {
-                    line,
-                    character: u64::MAX,
-                },
-                end: Position {
-                    line,
-                    character: u64::MAX,
-                },
-            };
-            let mut pos = lsp_range_to_kakoune(&range, &document.text, &ctx.offset_encoding).start;
-            pos.column = (pos.column - 1).max(1);
+            let line_text = get_line(line as usize, &document.text);
+            let mut pos =
+                lsp_position_to_kakoune(&x.range.end, &document.text, &ctx.offset_encoding);
+            pos.column = line_text.len_bytes() as u64;
             // separate all but the first diagnostic on the same line
             let sep = if lines_with_errors.insert(line) {
                 ""

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ use std::env;
 use std::fs;
 use std::io::{stdin, Read, Write};
 use std::os::unix::net::UnixStream;
+use std::panic;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
@@ -246,6 +247,10 @@ fn setup_logger(config: &Config, matches: &clap::ArgMatches<'_>) -> slog_scope::
         builder.destination(Destination::Stderr);
         builder.build().unwrap()
     };
+
+    panic::set_hook(Box::new(|panic_info| {
+        error!("panic: {}", panic_info);
+    }));
 
     slog_scope::set_global_logger(logger)
 }

--- a/src/position.rs
+++ b/src/position.rs
@@ -73,7 +73,7 @@ pub fn kakoune_position_to_lsp(
 /// If the line number is out-of-bounds, this will return the
 /// last line. This is useful because the language server might
 /// use a large value to convey "end of file".
-fn get_line(line_number: usize, text: &Rope) -> RopeSlice {
+pub fn get_line(line_number: usize, text: &Rope) -> RopeSlice {
     text.line(min(line_number, text.len_lines() - 1))
 }
 


### PR DESCRIPTION
Also adds a panic hook, since the integer overflow crashed the process without any information in the log.