### PR TITLE
Change val to reg, to fix snippets on newer versions of kak.

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1285,7 +1285,7 @@ face global SnippetsOtherPlaceholders black,yellow+F
 # Second param is the actual snippet
 def -hidden lsp-snippets-insert-completion -params 2 %{ eval -save-regs "a" %{
     reg 'a' "%arg{1}"
-    exec -draft "<a-;><a-/>%val[main_reg_a]<ret>d"
+    exec -draft "<a-;><a-/>%reg{a}<ret>d"
     eval -draft -verbatim lsp-snippets-insert %arg{2}
     remove-hooks window lsp-post-completion
     hook -once -group lsp-post-completion window InsertCompletionHide .* %{


### PR DESCRIPTION
[This issue](https://github.com/mawww/kakoune/issues/3507)
And overall why use `%val` for registers, when everywhere else there's `%reg` already?