### PR TITLE
Properly unescape = in key-value pair

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -517,6 +517,7 @@ eval "set -- $kak_quoted_opt_lsp_server_configuration"
 while [ $# -gt 0 ]; do
     key=${1%%=*}
     value=${1#*=}
+    value="$(printf %s "$value"|sed -e 's/\\=/=/g')"
     quotedkey='"'$(printf %s "$key"|sed -e 's/\\/\\\\/' -e 's/"/\\"/')'"'
 
     printf '%s = %s\n' "$quotedkey" "$value"


### PR DESCRIPTION
Unescapes `test=foo\=bar` to `key: test` and `value: foo=bar`.