### PR TITLE
Remove bash dependency by replacing here-string '<<<' with here-doc '<<'

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -619,9 +619,15 @@ define-command lsp-range-formatting -docstring "Format selections" %{
 define-command -hidden lsp-range-formatting-request -docstring "Format selections" %{
     nop %sh{
 ranges_str="$(for range in ${kak_selections_char_desc}; do
-    IFS=, read start end <<< $range
-    IFS=. read startline startcolumn <<< $start
-    IFS=. read endline endcolumn <<< $end
+    IFS=, read start end <<END
+    $range
+END
+    IFS=. read startline startcolumn <<END
+    $start
+END
+    IFS=. read endline endcolumn <<END
+    $end
+END
     printf '
 [[ranges]]
   [ranges.start]


### PR DESCRIPTION
The following pull request removes the dependency on **bash** by using **here-doc** instead of **here-string** as discussed [here](https://github.com/ul/kak-lsp/commit/23e229eb1ba649697af0c9895001cb161e3d4d04#commitcomment-40231590).

The fix has been tested on **MacOS** using `/bin/dash` as `KAKOUNE_POSIX_SHELL`.