### PR TITLE
Add semhl capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,11 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,7 +306,7 @@ dependencies = [
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "lsp-types 0.73.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lsp-types 0.77.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ropey 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -352,10 +357,10 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.73.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -823,6 +828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+"checksum base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum boxfnonce 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5988cb1d626264ac94100be357308f29ff7cbdd3b36bda27f450a4ee3f713426"
@@ -855,7 +861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libflate 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "784f4ec5908a9d7f4e53658906386667e8b02e9389a47cfebf45d324ba9e8d25"
 "checksum libflate_lz77 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum lsp-types 0.73.0 (registry+https://github.com/rust-lang/crates.io-index)" = "93d0cf64ea141b43d9e055f6b9df13f0bce32b103d84237509ce0a571ab9b159"
+"checksum lsp-types 0.77.0 (registry+https://github.com/rust-lang/crates.io-index)" = "897c6c8930fbf12b67deffc83729287bb379dd5e5a4bd0ae2d81eff8d6503db6"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ dirs = "2.0.2"
 enum_primitive = "0.1.1"
 glob = "0.3.0"
 itertools = "0.9.0"
-lsp-types = { version = "0.73.0", features = ["proposed"] }
+lsp-types = { version = "0.77.0", features = ["proposed"] }
 jsonrpc-core = "14.2.0"
 libc = "0.2.71"
 rand = "0.7.3"

--- a/src/general.rs
+++ b/src/general.rs
@@ -92,6 +92,7 @@ pub fn initialize(
                         deprecated_support: Some(false),
                         preselect_support: Some(false),
                         tag_support: None,
+                        insert_replace_support: None,
                     }),
                     completion_item_kind: Some(CompletionItemKindCapability {
                         value_set: Some(vec![
@@ -271,8 +272,12 @@ pub fn capabilities(meta: EditorMeta, ctx: &mut Context) {
 
     let mut features = vec![];
 
-    if server_capabilities.hover_provider.unwrap_or(false) {
-        features.push("lsp-hover");
+    match server_capabilities
+        .hover_provider.as_ref()
+        .unwrap_or(&HoverProviderCapability::Simple(false))
+    {
+        HoverProviderCapability::Simple(false) => (),
+        _ => features.push("lsp-hover"),
     }
 
     if server_capabilities.completion_provider.is_some() {

--- a/src/language_features/ccls.rs
+++ b/src/language_features/ccls.rs
@@ -5,7 +5,7 @@ use crate::types::*;
 use crate::util::*;
 use itertools::Itertools;
 use jsonrpc_core::Params;
-use lsp_types::request::{GotoDefinitionResponse, Request};
+use lsp_types::request::{Request};
 use lsp_types::*;
 use serde;
 use serde::Deserialize;

--- a/src/language_features/completion.rs
+++ b/src/language_features/completion.rs
@@ -77,14 +77,22 @@ pub fn editor_completion(
             // However, we can support simple text edits that only replace the token left of the
             // cursor. Kakoune will do this very edit if we simply pass it the replacement string
             // as completion.
-            let is_simple_text_edit = x.text_edit.as_ref().map_or(false, |text_edit| {
-                text_edit.range.start.line + 1 == params.position.line
-                    && text_edit.range.start.character + 1 == params.completion.offset
-                    && text_edit.range.end.line + 1 == params.position.line
-                    && text_edit.range.end.character + 1 == params.position.column
+            let is_simple_text_edit = x.text_edit.as_ref().map_or(false, |cte| {
+                if let CompletionTextEdit::Edit(text_edit) = cte {
+                    text_edit.range.start.line + 1 == params.position.line
+                        && text_edit.range.start.character + 1 == params.completion.offset
+                        && text_edit.range.end.line + 1 == params.position.line
+                        && text_edit.range.end.character + 1 == params.position.column
+                } else {
+                    false
+                }
             });
             let insert_text = &if is_simple_text_edit {
-                x.text_edit.unwrap().new_text
+                if let CompletionTextEdit::Edit(te) = x.text_edit.unwrap() {
+                    te.new_text
+                } else {
+                    x.insert_text.unwrap_or(x.label)
+                }
             } else {
                 x.insert_text.unwrap_or(x.label)
             };

--- a/src/language_features/document_symbol.rs
+++ b/src/language_features/document_symbol.rs
@@ -10,6 +10,8 @@ pub fn text_document_document_symbol(meta: EditorMeta, ctx: &mut Context) {
         text_document: TextDocumentIdentifier {
             uri: Url::from_file_path(&meta.buffile).unwrap(),
         },
+        partial_result_params: Default::default(),
+        work_done_progress_params: Default::default(),
     };
     ctx.call::<DocumentSymbolRequest, _>(
         meta,

--- a/src/language_features/goto.rs
+++ b/src/language_features/goto.rs
@@ -3,13 +3,8 @@ use crate::position::lsp_range_to_kakoune;
 use crate::types::{EditorMeta, EditorParams, PositionParams};
 use crate::util::{editor_quote, get_file_contents, get_lsp_position};
 use itertools::Itertools;
-use lsp_types::request::{
-    GotoDefinition, GotoDefinitionResponse, GotoImplementation, GotoTypeDefinition, References,
-};
-use lsp_types::{
-    Location, LocationLink, ReferenceContext, ReferenceParams, TextDocumentIdentifier,
-    TextDocumentPositionParams,
-};
+use lsp_types::request::{GotoDefinition, GotoImplementation, GotoTypeDefinition, References};
+use lsp_types::*;
 use serde::Deserialize;
 use url::Url;
 
@@ -94,11 +89,15 @@ pub fn goto_locations(meta: EditorMeta, locations: &[Location], ctx: &mut Contex
 
 pub fn text_document_definition(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
     let params = PositionParams::deserialize(params).unwrap();
-    let req_params = TextDocumentPositionParams {
-        text_document: TextDocumentIdentifier {
-            uri: Url::from_file_path(&meta.buffile).unwrap(),
+    let req_params = GotoDefinitionParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier {
+                uri: Url::from_file_path(&meta.buffile).unwrap(),
+            },
+            position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
+        partial_result_params: Default::default(),
+        work_done_progress_params: Default::default(),
     };
     ctx.call::<GotoDefinition, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
         goto(meta, result, ctx);
@@ -107,11 +106,15 @@ pub fn text_document_definition(meta: EditorMeta, params: EditorParams, ctx: &mu
 
 pub fn text_document_implementation(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
     let params = PositionParams::deserialize(params).unwrap();
-    let req_params = TextDocumentPositionParams {
-        text_document: TextDocumentIdentifier {
-            uri: Url::from_file_path(&meta.buffile).unwrap(),
+    let req_params = GotoDefinitionParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier {
+                uri: Url::from_file_path(&meta.buffile).unwrap(),
+            },
+            position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
+        partial_result_params: Default::default(),
+        work_done_progress_params: Default::default(),
     };
     ctx.call::<GotoImplementation, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
         goto(meta, result, ctx);
@@ -120,11 +123,15 @@ pub fn text_document_implementation(meta: EditorMeta, params: EditorParams, ctx:
 
 pub fn text_document_type_definition(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
     let params = PositionParams::deserialize(params).unwrap();
-    let req_params = TextDocumentPositionParams {
-        text_document: TextDocumentIdentifier {
-            uri: Url::from_file_path(&meta.buffile).unwrap(),
+    let req_params = GotoDefinitionParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier {
+                uri: Url::from_file_path(&meta.buffile).unwrap(),
+            },
+            position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
+        partial_result_params: Default::default(),
+        work_done_progress_params: Default::default(),
     };
     ctx.call::<GotoTypeDefinition, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
         goto(meta, result, ctx);
@@ -143,6 +150,7 @@ pub fn text_document_references(meta: EditorMeta, params: EditorParams, ctx: &mu
         context: ReferenceContext {
             include_declaration: true,
         },
+        partial_result_params: Default::default(),
         work_done_progress_params: Default::default(),
     };
     ctx.call::<References, _>(meta, req_params, move |ctx: &mut Context, meta, result| {

--- a/src/language_features/highlights.rs
+++ b/src/language_features/highlights.rs
@@ -5,18 +5,22 @@ use crate::util::get_lsp_position;
 use itertools::Itertools;
 use lsp_types::{
     request::DocumentHighlightRequest, DocumentHighlight, DocumentHighlightKind::Write,
-    TextDocumentIdentifier, TextDocumentPositionParams,
+    DocumentHighlightParams, TextDocumentIdentifier, TextDocumentPositionParams,
 };
 use serde::Deserialize;
 use url::Url;
 
 pub fn text_document_highlights(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
     let params = PositionParams::deserialize(params).unwrap();
-    let req_params = TextDocumentPositionParams {
-        text_document: TextDocumentIdentifier {
-            uri: Url::from_file_path(&meta.buffile).unwrap(),
+    let req_params = DocumentHighlightParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier {
+                uri: Url::from_file_path(&meta.buffile).unwrap(),
+            },
+            position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
+        partial_result_params: Default::default(),
+        work_done_progress_params: Default::default(),
     };
     ctx.call::<DocumentHighlightRequest, _>(
         meta,

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -10,11 +10,14 @@ use url::Url;
 
 pub fn text_document_hover(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
     let params = PositionParams::deserialize(params).unwrap();
-    let req_params = TextDocumentPositionParams {
-        text_document: TextDocumentIdentifier {
-            uri: Url::from_file_path(&meta.buffile).unwrap(),
+    let req_params = HoverParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier {
+                uri: Url::from_file_path(&meta.buffile).unwrap(),
+            },
+            position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
+        work_done_progress_params: Default::default(),
     };
     ctx.call::<HoverRequest, _>(meta, req_params, move |ctx: &mut Context, meta, result| {
         editor_hover(meta, params, result, ctx)

--- a/src/language_features/signature_help.rs
+++ b/src/language_features/signature_help.rs
@@ -8,11 +8,15 @@ use url::Url;
 
 pub fn text_document_signature_help(meta: EditorMeta, params: EditorParams, ctx: &mut Context) {
     let params = PositionParams::deserialize(params).unwrap();
-    let req_params = TextDocumentPositionParams {
-        text_document: TextDocumentIdentifier {
-            uri: Url::from_file_path(&meta.buffile).unwrap(),
+    let req_params = SignatureHelpParams {
+        context: None,
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier {
+                uri: Url::from_file_path(&meta.buffile).unwrap(),
+            },
+            position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
         },
-        position: get_lsp_position(&meta.buffile, &params.position, ctx).unwrap(),
+        work_done_progress_params: Default::default(),
     };
     ctx.call::<SignatureHelpRequest, _>(
         meta,


### PR DESCRIPTION
Show semantic highlighting and semantic token info in `lsp-capabilities`

The available scopes, types and modifiers can be quite useful for configuring faces, so i display them there as well.

The "old" eclipse Theia semantic highlighting:
![image](https://user-images.githubusercontent.com/3133596/87873292-8b86ea00-c9c0-11ea-90ee-a8c59f4c84a2.png)

The "new" semantic tokens:
![image](https://user-images.githubusercontent.com/3133596/87873314-dc96de00-c9c0-11ea-81af-1113e9d5ecfd.png)

This is based on my other pr #373, since clangd 11 is the only server I use with semantic tokens support afaik.

A way to access lsp-capabilities and check for specific capabilities might be useful as well for configuration, like automatically adding the `lsp-semantic-token` hooks if the server supports it