### PR TITLE
Rust use component for active toolchain

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -42,13 +42,13 @@ timeout = 1800 # seconds = 30 minutes
 filetypes = ["rust"]
 roots = ["Cargo.toml"]
 command = "sh"
-args = ["-c", "$(rustup which rls)"]
+args = ["-c", "if command -v rustup >/dev/null; then $(rustup which rls); else rls; fi"]
 
 # [language.rust]
 # filetypes = ["rust"]
 # roots = ["Cargo.toml"]
 # command = "sh"
-# args = ["-c", "$(rustup which rust-analyzer)"]
+# args = ["-c", "if command -v rustup >/dev/null; then $(rustup which rust-analyzer); else rust-analyzer; fi"]
 
 [language.crystal]
 filetypes = ["crystal"]

--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -41,7 +41,14 @@ timeout = 1800 # seconds = 30 minutes
 [language.rust]
 filetypes = ["rust"]
 roots = ["Cargo.toml"]
-command = "rls"
+command = "sh"
+args = ["-c", "$(rustup which rls)"]
+
+# [language.rust]
+# filetypes = ["rust"]
+# roots = ["Cargo.toml"]
+# command = "sh"
+# args = ["-c", "$(rustup which rust-analyzer)"]
 
 [language.crystal]
 filetypes = ["crystal"]


### PR DESCRIPTION
Use rustup to figure out what is the active toolchain and use that binary
Added rust-analyzer but commented as it is only available in nightly
by using rust-analyzer-preview