### PR TITLE
kak-lsp.toml: Default to clangd instead of cquery.

### DIFF
--- a/kak-lsp.toml
+++ b/kak-lsp.toml
@@ -105,9 +105,8 @@ offset_encoding = "utf-8"
 
 [language.c_cpp]
 filetypes = ["c", "cpp"]
-roots = ["compile_commands.json", ".cquery"]
-command = "cquery"
-args = ["--init={\"cacheDirectory\":\"/tmp/cquery\",\"highlight\":{\"enabled\":true}}"]
+roots = ["compile_commands.json", ".clangd"]
+command = "clangd"
 
 [language.haskell]
 filetypes = ["haskell"]


### PR DESCRIPTION
cquery development has been abandoned, and clangd is both widely available (as part of clang) and has the resources of the LLVM project behind it.

Fixes #380.