### PR TITLE
don't occupy space in gutter if there are no any errors

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -70,7 +70,7 @@ declare-option -docstring "Number of warnings" int lsp_diagnostic_warning_count 
 
 declare-option -hidden completions lsp_completions
 declare-option -hidden range-specs lsp_errors
-declare-option -hidden line-specs lsp_error_lines 0 '0| '
+declare-option -hidden line-specs lsp_error_lines
 declare-option -hidden range-specs cquery_semhl
 declare-option -hidden int lsp_timestamp -1
 declare-option -hidden range-specs lsp_references


### PR DESCRIPTION
If there are no any errors `lsp_error_lines` still occupies one space making left gutter unnecessarily wider.
I think it should behave same as [git-diff](https://github.com/mawww/kakoune/blob/2c437cfa02ca568750182209ef6249c6975243a5/rc/tools/git.kak#L31), occupy space only if there is something to show.