### PR TITLE
Update semantic tokens to LSP 3.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.73 (registry+https://github.com/rust-lang/crates.io-index)",
- "lsp-types 0.77.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lsp-types 0.80.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ropey 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.77.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -861,7 +861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libflate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e9bac9023e1db29c084f9f8cd9d3852e5e8fddf98fb47c4964a0ea4663d95949"
 "checksum libflate_lz77 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
 "checksum log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
-"checksum lsp-types 0.77.0 (registry+https://github.com/rust-lang/crates.io-index)" = "897c6c8930fbf12b67deffc83729287bb379dd5e5a4bd0ae2d81eff8d6503db6"
+"checksum lsp-types 0.80.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f4265e2715bdacbb4dad029fce525e420cd66dc0af24ff9cb996a8ab48ac92ef"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ dirs = "2.0.2"
 enum_primitive = "0.1.1"
 glob = "0.3.0"
 itertools = "0.9.0"
-lsp-types = { version = "0.77.0", features = ["proposed"] }
+lsp-types = { version = "0.80.0", features = ["proposed"] }
 jsonrpc-core = "14.2.0"
 libc = "0.2.71"
 rand = "0.7.3"

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -906,7 +906,7 @@ client    = "%s"
 buffile   = "%s"
 filetype  = "%s"
 version   = %d
-method    = "textDocument/semanticTokens"
+method    = "textDocument/semanticTokens/full"
 [params]
 ' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
 }
@@ -1165,20 +1165,22 @@ define-command lsp-workspace-symbol-incr -docstring "Open buffer with an increme
     declare-option -hidden str lsp_ws_filetype %opt{filetype}
     declare-option -hidden int lsp_ws_timestamp %val{timestamp}
     declare-option -hidden str lsp_ws_query
-    edit! -scratch *symbols*
-    set-option buffer filetype grep
-    set-option buffer grep_current_line 0
-    prompt -on-change %{ try %{
-        # lsp-show-workspace-symbol triggers on-change somehow which causes inifinite loop
-        # the following check prevents it
-        evaluate-commands %sh{
-            if [ "${kak_opt_lsp_ws_query}" = "${kak_text}" ];
-            then echo 'fail';
-            else echo 'set current lsp_ws_query %val{text}';
-            fi
-        }
-        lsp-workspace-symbol-buffer %opt{lsp_ws_buffile} %opt{lsp_ws_filetype} %opt{lsp_ws_timestamp} %val{text}
-    }} -on-abort %{execute-keys ga} 'Query: ' nop
+    evaluate-commands -try-client %opt[toolsclient] %{
+        edit! -scratch *symbols*
+        set-option buffer filetype grep
+        set-option buffer grep_current_line 0
+        prompt -on-change %{ try %{
+            # lsp-show-workspace-symbol triggers on-change somehow which causes inifinite loop
+            # the following check prevents it
+            evaluate-commands %sh{
+                if [ "${kak_opt_lsp_ws_query}" = "${kak_text}" ];
+                then echo 'fail';
+                else echo 'set current lsp_ws_query %val{text}';
+                fi
+            }
+            lsp-workspace-symbol-buffer %opt{lsp_ws_buffile} %opt{lsp_ws_filetype} %opt{lsp_ws_timestamp} %val{text}
+        }} -on-abort %{execute-keys ga} 'Query: ' nop
+    }
 }
 
 ### Hooks and highlighters ###

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -262,7 +262,7 @@ fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
         "update-semantic-highlighting" => {
             semantic_highlighting::editor_update(meta, params, &mut ctx);
         }
-        request::SemanticTokensRequest::METHOD => {
+        request::SemanticTokensFullRequest::METHOD => {
             semantic_tokens::tokens_request(meta, params, ctx);
         }
 

--- a/src/general.rs
+++ b/src/general.rs
@@ -38,7 +38,7 @@ pub fn initialize(
                     dynamic_registration: Some(false),
                 }),
                 did_change_watched_files: None,
-                symbol: Some(SymbolCapability {
+                symbol: Some(WorkspaceSymbolClientCapabilities{
                     dynamic_registration: Some(false),
                     symbol_kind: Some(SymbolKindCapability {
                         value_set: Some(vec![
@@ -70,6 +70,7 @@ pub fn initialize(
                             SymbolKind::TypeParameter,
                         ]),
                     }),
+                    tag_support: None,
                 }),
                 execute_command: Some(GenericCapability {
                     dynamic_registration: Some(false),
@@ -146,10 +147,11 @@ pub fn initialize(
                 document_highlight: Some(GenericCapability {
                     dynamic_registration: Some(false),
                 }),
-                document_symbol: Some(DocumentSymbolCapability {
+                document_symbol: Some(DocumentSymbolClientCapabilities {
                     dynamic_registration: Some(false),
                     symbol_kind: None,
                     hierarchical_document_symbol_support: None,
+                    tag_support: None,
                 }),
                 formatting: Some(GenericCapability {
                     dynamic_registration: Some(false),
@@ -220,6 +222,10 @@ pub fn initialize(
                 }),
                 semantic_tokens: Some(SemanticTokensClientCapabilities {
                     dynamic_registration: Some(false),
+                    requests: SemanticTokensClientCapabilitiesRequests {
+                      range: Some(false),
+                      full: Some(SemanticTokensFullOptions::Bool(true)),
+                    },
                     token_types: ctx
                         .config
                         .semantic_tokens
@@ -234,6 +240,7 @@ pub fn initialize(
                         .cloned()
                         .map(|x| x.into())
                         .collect(),
+                    formats: vec![TokenFormat::RELATIVE],
                 }),
             }),
             window: Some(WindowClientCapabilities {

--- a/src/language_features/semantic_tokens.rs
+++ b/src/language_features/semantic_tokens.rs
@@ -2,7 +2,7 @@ use crate::context::Context;
 use crate::position::lsp_range_to_kakoune;
 use crate::types::{EditorMeta, EditorParams};
 use crate::util::editor_quote;
-use lsp_types::request::SemanticTokensRequest;
+use lsp_types::request::SemanticTokensFullRequest;
 use lsp_types::{
     Position, Range, SemanticToken, SemanticTokensOptions, SemanticTokensParams,
     SemanticTokensRegistrationOptions, SemanticTokensResult, SemanticTokensServerCapabilities::*,
@@ -18,7 +18,7 @@ pub fn tokens_request(meta: EditorMeta, _params: EditorParams, ctx: &mut Context
         },
         work_done_progress_params: Default::default(),
     };
-    ctx.call::<SemanticTokensRequest, _>(meta, req_params, move |ctx, meta, response| {
+    ctx.call::<SemanticTokensFullRequest, _>(meta, req_params, move |ctx, meta, response| {
         if let Some(response) = response {
             tokens_response(meta, response, ctx);
         }


### PR DESCRIPTION
Updates lsp-types to 0.80.0
Works with clangd 12 (latest master)
