### PR TITLE
clangd-switch-source-header

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -857,6 +857,24 @@ column    = %d
 ' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" $kind ${kak_cursor_line} ${kak_cursor_column} | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
 }
 
+# clangd Extensions
+
+define-command clangd-switch-source-header -docstring "clangd-switch-source-header: Switch source/header." %{
+    lsp-did-change-and-then clangd-switch-source-header-request
+}
+
+define-command -hidden clangd-switch-source-header-request -docstring "clangd-switch-source-header: Switch source/header." %{
+    nop %sh{ (printf '
+session   = "%s"
+client    = "%s"
+buffile   = "%s"
+filetype  = "%s"
+version   = %d
+method    = "textDocument/switchSourceHeader"
+[params]
+' "${kak_session}" "${kak_client}" "${kak_buffile}" "${kak_opt_filetype}" "${kak_timestamp}" | eval ${kak_opt_lsp_cmd} --request) > /dev/null 2>&1 < /dev/null & }
+}
+
 # eclipse.jdt.ls Extension
 #
 define-command ejdtls-organize-imports -docstring "ejdtls-organize-imports: Organize imports." %{

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -283,6 +283,11 @@ fn dispatch_editor_request(request: EditorRequest, mut ctx: &mut Context) {
             ccls::member(meta, params, ctx);
         }
 
+        // clangd
+        clangd::SwitchSourceHeaderRequest::METHOD => {
+            clangd::switch_source_header(meta, ctx);
+        }
+
         // eclipse.jdt.ls
         "eclipse.jdt.ls/organizeImports" => {
             eclipse_jdt_ls::organize_imports(meta, ctx);

--- a/src/language_features/clangd.rs
+++ b/src/language_features/clangd.rs
@@ -1,0 +1,33 @@
+use lsp_types::request::Request;
+use crate::context::*;
+use crate::types::*;
+use crate::util::*;
+use lsp_types::*;
+
+pub struct SwitchSourceHeaderRequest {}
+
+impl Request for SwitchSourceHeaderRequest {
+    type Params = TextDocumentIdentifier;
+    type Result = Option<Url>;
+    const METHOD: &'static str = "textDocument/switchSourceHeader";
+}
+
+pub fn switch_source_header(meta: EditorMeta, ctx: &mut Context) {
+    let req_params = TextDocumentIdentifier {
+      uri: Url::from_file_path(&meta.buffile).unwrap(),
+    };
+    ctx.call::<SwitchSourceHeaderRequest, _>(
+        meta,
+        req_params,
+        move |ctx: &mut Context, meta, response| match response {
+            Some(response) => {
+              let command = format!(
+                "evaluate-commands -try-client %opt{{jumpclient}} %{{edit {}}}",
+                 editor_quote(response.to_file_path().unwrap().to_str().unwrap()),
+              );
+              ctx.exec(meta, command);
+            }
+            None => return,
+        },
+    );
+}

--- a/src/language_features/mod.rs
+++ b/src/language_features/mod.rs
@@ -14,3 +14,4 @@ pub mod rust_analyzer;
 pub mod semantic_highlighting;
 pub mod semantic_tokens;
 pub mod signature_help;
+pub mod clangd;


### PR DESCRIPTION
Implement `textDocument/switchHeaderSource` as specified by https://clangd.llvm.org/extensions.html#switch-between-sourceheader
