### PR TITLE
Add KAK_LSP_FORCE_PROJECT_ROOT variable to force a project root

### DIFF
--- a/src/project_root.rs
+++ b/src/project_root.rs
@@ -4,6 +4,10 @@ use std::env;
 use std::path::PathBuf;
 
 pub fn find_project_root(language: &str, markers: &[String], path: &str) -> String {
+    if let Ok(force_root) = env::var("KAK_LSP_FORCE_PROJECT_ROOT") {
+        debug!("Using $KAK_LSP_FORCE_PROJECT_ROOT as project root: \"{}\"", force_root);
+        return force_root;
+    }
     let vars = gather_env_roots(language);
     if vars.is_empty() {
         roots_by_marker(markers, path)


### PR DESCRIPTION
Unlike the KAK_LSP_PROJECT_ROOT_$LANGUAGE variables, this variable is
always used, even if the current file is not in the directory of the
project root.

I use this variable with `direnv`, with an `.envrc` like so:
export KAK_LSP_FORCE_PROJECT_ROOT=$(pwd)

The reason to use this variable is go-to-definition to libraries.
With Go, Rust, and C, and probably many other languages, when you use
go-to-definition and you end up in library code, the root is generally
outside of the current project you're working on. This means that the
kak-lsp starts up a new language server, with all the initialization
time that takes. The language server possibly loses the in-memory and
on-disk caches it has set up for the main project. It also loses the
project's build configuration, so with some languages, like C,
you often can't use go-to-definition in library headers.