### PR TITLE
Change root glob resolution

### DIFF
--- a/src/project_root.rs
+++ b/src/project_root.rs
@@ -37,9 +37,9 @@ fn roots_by_marker(to_editor: &ToEditorSender, roots: &[String], path: &str) -> 
         src.pop();
     }
 
-    for root in roots {
-        let mut pwd = src.clone();
-        loop {
+    let mut pwd = src.clone();
+    loop {
+        for root in roots {
             // unwrap should be safe here because we walk up path previously converted from str
             let matches = glob(pwd.join(root).to_str().unwrap());
             if let Ok(mut m) = matches {
@@ -53,9 +53,9 @@ fn roots_by_marker(to_editor: &ToEditorSender, roots: &[String], path: &str) -> 
                     return root_dir;
                 }
             }
-            if !pwd.pop() {
-                break;
-            }
+        }
+        if !pwd.pop() {
+            break;
         }
     }
     src.to_str().unwrap().to_string()


### PR DESCRIPTION
A bit subjective, but to me when the project is looking for roots it should stop at the first directory matching any of the globs, rather than going through each glob in order and matching the first directory containing it.

It leads to counterintuitive stuff like a Python project that uses `setup.py` and `requirements.txt` not being recognized as the root for itself because a parent contains a `pyproject.toml` as a uv workspace.