### PR TITLE
Add inlay hint textedit support

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -356,6 +356,16 @@ lsp-inlay-hints-enable global
 
 You can change the hints' face with `set-face global InlayHint <face>`.
 
+Some language servers support "applying" inlay hints: inserting them as text into your document.
+For example, when using `basedpyright` to write Python,
+inlay hints which represent type hints can be explicitly inserted into your code.
+
+We provide two commands for applying inlay hints:
+`lsp-inlay-hint-apply-nearest` and `lsp-inlay-hint-apply-selected`.
+They both operate _per selection_.
+`nearest` applies whichever hint is closest to the cursor, *on the same line*.
+`selected` applies *all* hints that fall inside the selection.
+
 === Semantic Tokens
 
 kakoune-lsp supports the semanticTokens feature for semantic highlighting. If the language server supports it, you can enable it with:

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1232,6 +1232,14 @@ define-command -hidden lsp-inlay-hints -docstring "lsp-inlay-hints: request inla
     }
 }
 
+define-command lsp-inlay-hint-apply-nearest -docstring "Apply the textedit for the inlay hint nearest the cursor, for each selection" %{
+    lsp-send kakoune/inlay-hint-apply-nearest %val{selection_count} %val{selections_desc}
+}
+
+define-command lsp-inlay-hint-apply-selected -docstring "Apply the textedit for the inlay hints overlapping with the selections" %{
+    lsp-send kakoune/inlay-hint-apply-selected %val{selection_count} %val{selections_desc}
+}
+
 # CCLS Extension
 
 define-command ccls-navigate -docstring "Navigate C/C++/ObjectiveC file" -params 1 %{

--- a/src/context.rs
+++ b/src/context.rs
@@ -79,6 +79,7 @@ pub struct Context {
     pub diagnostics: HashMap<String, Vec<(ServerId, Diagnostic)>>,
     pub documents: HashMap<String, Document>,
     pub dynamic_config: DynamicConfig,
+    pub inlay_hints: HashMap<String, Vec<(ServerId, InlayHint)>>,
     pub language_servers: BTreeMap<ServerId, ServerSettings>,
     pub route_cache: HashMap<(ServerName, RootPath), ServerId>,
     pub outstanding_requests:
@@ -118,6 +119,7 @@ impl Context {
             diagnostics: Default::default(),
             documents: Default::default(),
             dynamic_config: DynamicConfig::default(),
+            inlay_hints: Default::default(),
             language_servers: BTreeMap::new(),
             route_cache: HashMap::new(),
             outstanding_requests: HashMap::default(),

--- a/src/language_features/inlay_hints.rs
+++ b/src/language_features/inlay_hints.rs
@@ -1,3 +1,5 @@
+use std::{borrow::Cow, collections::HashMap};
+
 use itertools::Itertools;
 use lsp_types::{
     request::InlayHintRequest, InlayHint, InlayHintLabel, InlayHintParams, Position, Range,
@@ -8,7 +10,10 @@ use crate::{
     capabilities::{attempt_server_capability, CAPABILITY_INLAY_HINTS},
     context::{Context, RequestParams},
     markup::escape_kakoune_markup,
-    position::lsp_position_to_kakoune,
+    position::{
+        kakoune_range_to_lsp, lsp_position_to_kakoune, parse_kakoune_range, ranges_overlap,
+    },
+    text_edit::apply_text_edits,
     types::{EditorMeta, ServerId},
     util::{editor_quote, escape_tuple_element},
 };
@@ -71,8 +76,9 @@ pub fn inlay_hints_response(
         Some(document) => document,
         None => return,
     };
+
     let ranges = inlay_hints
-        .into_iter()
+        .iter()
         .map(
             |(
                 server_id,
@@ -84,13 +90,13 @@ pub fn inlay_hints_response(
                     ..
                 },
             )| {
-                let server = ctx.server(server_id);
+                let server = ctx.server(*server_id);
                 let position =
-                    lsp_position_to_kakoune(&position, &document.text, server.offset_encoding);
+                    lsp_position_to_kakoune(position, &document.text, server.offset_encoding);
                 let label = match label {
-                    InlayHintLabel::String(s) => s,
+                    InlayHintLabel::String(s) => Cow::Borrowed(s),
                     InlayHintLabel::LabelParts(parts) => {
-                        parts.iter().map(|x| x.value.as_str()).collect()
+                        Cow::Owned(parts.iter().map(|x| x.value.as_str()).collect())
                     }
                 };
                 let padding_left = if padding_left.unwrap_or(false) {
@@ -110,6 +116,9 @@ pub fn inlay_hints_response(
             },
         )
         .join(" ");
+
+    ctx.inlay_hints.insert(meta.buffile.clone(), inlay_hints);
+
     let version = meta.version;
     let command = format!("set-option buffer lsp_inlay_hints {version} {ranges}");
     let command = format!(
@@ -118,4 +127,130 @@ pub fn inlay_hints_response(
         &command
     );
     ctx.exec(meta, command)
+}
+
+#[derive(Debug)]
+pub enum InlayHintApplyKind {
+    /// Select the closest hint on the same line as the cursors
+    Nearest,
+    /// Select ANY hints whose position overlaps with the selections
+    Selected,
+}
+
+#[derive(Debug)]
+pub struct InlayHintApplyParams {
+    pub selections_desc: Vec<String>,
+    pub kind: InlayHintApplyKind,
+}
+
+/// This function applies TextEdits contained in inlay hints, where the user's selections_desc
+/// describe which inlay hints we'll apply.
+/// The heuristic we use to pick the inlay hints to apply depends on the InlayHintApplyKind
+/// specified in the Params.
+pub fn inlay_hint_apply(meta: EditorMeta, params: InlayHintApplyParams, ctx: &mut Context) {
+    // we operate per selection/cursor
+    for selection_desc in &params.selections_desc {
+        let (kak_range, cursor) = parse_kakoune_range(selection_desc);
+
+        // this is a map of server id -> vector of textedits
+        let edits_by_server = {
+            let Some(document) = ctx.documents.get(&meta.buffile) else {
+                return;
+            };
+
+            // all hints for this buffile, with their server_id and position
+            // the kak position is later used by the Nearest apply kind
+            let all_hints =
+                ctx.inlay_hints
+                    .get(&meta.buffile)
+                    .unwrap()
+                    .iter()
+                    .map(|(server_id, hint)| {
+                        let server = ctx.server(*server_id);
+                        let kak_pos = lsp_position_to_kakoune(
+                            &hint.position,
+                            &document.text,
+                            server.offset_encoding,
+                        );
+                        (*server_id, hint, kak_pos)
+                    });
+
+            // an iterator of the inlay hints we select to apply
+            // iterated item = tuple (server id, inlay hint)
+            let hints_to_apply: Box<dyn Iterator<Item = (usize, &InlayHint)> + '_> =
+                // the filtering/selection logic depends on which kind of apply the user wants
+                match &params.kind {
+                    // nearest: closest hint on same line
+                    InlayHintApplyKind::Nearest => {
+                        let it = all_hints
+                            // only consider same line as cursor
+                            .filter(|(_, _, pos)| pos.line == cursor.line)
+                            // pick hint with minimum distance from cursor
+                            .min_by_key(|(_, _, pos)| pos.column.abs_diff(cursor.column) as u64)
+                            // drop the position from the tuple
+                            .map(|(server_id, hint, _)| (server_id, hint))
+                            .into_iter();
+                        Box::new(it)
+                    }
+                    // selected: ALL hints whose position is inside the selection range
+                    InlayHintApplyKind::Selected => {
+                        let it = all_hints
+                            .filter(|(server_id, hint, _)| {
+                                let server = ctx.server(*server_id);
+                                ranges_overlap(
+                                    // ranges_overlap needs LSP Ranges, so we must convert
+                                    // this kak range to the LSP range format
+                                    kakoune_range_to_lsp(
+                                        &kak_range,
+                                        &document.text,
+                                        server.offset_encoding,
+                                    ),
+                                    // hints only have a single position, but we can cheat by
+                                    // building a zero-sized range where start == end
+                                    Range {
+                                        start: hint.position,
+                                        end: hint.position,
+                                    },
+                                )
+                            })
+                            // drop the kak position from tuple
+                            .map(|(server_id, hint, _)| (server_id, hint));
+                        Box::new(it)
+                    }
+                };
+
+            // because each hint comes with its own server_id, we respect that and build a map.
+            // even though it's most likely the server_ids will all be the same, this is more correct
+            let mut edits_by_server: HashMap<usize, Vec<lsp_types::TextEdit>> = HashMap::new();
+
+            for (server_id, hint) in hints_to_apply {
+                if let Some(edits) = hint.text_edits.as_ref().filter(|e| !e.is_empty()) {
+                    edits_by_server
+                        .entry(server_id)
+                        .or_default()
+                        .extend(edits.iter().cloned());
+                }
+            }
+            edits_by_server
+        };
+
+        if edits_by_server.is_empty() {
+            ctx.show_error(meta.clone(), "no textedits available to apply");
+            continue;
+        }
+
+        let uri = Url::from_file_path(&meta.buffile).unwrap();
+
+        // FIXME: https://github.com/kakoune-lsp/kakoune-lsp/issues/873
+        // we expect this to break if multiple servers provide InlayHints with textedits
+        // for the same buffile, because the servers won't know about each other.
+        // So if server A inserts a line at line N, that messes up server B's edits at line >N.
+        //
+        // Solution could be to combine all edits from all servers into a Vec,
+        // and sort them by start (or end?) position.
+        // If the ranges don't overlap, should be correct.
+        for (server_id, edits) in edits_by_server {
+            apply_text_edits(server_id, meta.clone(), uri.clone(), edits, ctx);
+        }
+    }
 }


### PR DESCRIPTION
~~Added a new method kakoune/inlay-hint-apply-textedit. There is now a Kakoune command that calls this method. It applies the TextEdits associated with the inlayHint that's nearest the cursor.~~

There is now a "nearest" and "selected" version of the command. Nearest applies the hint that's closest to the cursor, on the same line. Selected applies all hints that fall within the selections. Both commands now use `selections_desc` and operate per-selection.