### PR TITLE
Add lean workspace discovery workaround

### DIFF
--- a/rc/servers.kak
+++ b/rc/servers.kak
@@ -209,11 +209,21 @@ hook -group lsp-filetype-html global BufSetOption filetype=html %{
 }
 
 hook -group lsp-filetype-lean global BufSetOption filetype=lean %{
-    set-option buffer lsp_servers %{
+    # The lean lsp server ignores the rootUri set in the LSP initialization
+    # options. Instead, we must ensure that the cwd is in the workspace root.
+    set-option buffer lsp_servers "
         [lake]
-        root_globs = ["lakefile.toml", ".git", ".hg"]
-        args = ["serve"]
-    }
+        root_globs = ['lakefile.lean', 'lakefile.toml', '.git', '.hg']
+        command = 'sh'
+        args = [
+            '-c',
+            '''
+              kak_buffile=%val{buffile}
+              %opt{lsp_find_root} lakefile.lean lakefile.toml .git .hg >/dev/null
+              exec lake serve
+            '''
+        ]
+    "
 }
 
 hook -group lsp-filetype-vue global BufSetOption filetype=(?:vue) %{


### PR DESCRIPTION
This change was discussed in #860 

The lean LSP server ignores the rootUri we send it in the LSP initialisation options. So this workaround ensures that the cwd of the lean-lsp process is set to the discovered workspace root. The lean-lsp behaviour is now documented [in their source](https://github.com/leanprover/lean4/blob/2da5b528b7fffda67976214b7fc7c42168133533/src/Lean/Server/ProtocolOverview.lean#L80).

[on lean zulip](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/LSP.20lakefile.20discovery.20uses.20PWD.20but.20should.20use.20LSP.20workspace/with/547533026) I discussed with a lean developer and it seems this is not likely to change.

Sorry for taking so long to get around to submitting this PR :sob: 

