### PR TITLE
Fix lsp-find-error incorrectly handling --previous flag

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -1503,6 +1503,7 @@ Valid arguments are 'error', 'warning', 'info', 'hint'.
 If no arguments are specified, 'error' is implied.
 " %{
     evaluate-commands %sh{
+	    previous=false
         diagnostic_faces=
         types=
         add_face() {


### PR DESCRIPTION
In the lsp-find-error command, the $previous variable was only set when --previous was passed, and remained unset otherwise. Evaluating an empty string as a boolean with if statements is always true. Explicitly setting previous=false as the default state, and overriding to previous=true if the --previous flag was given fixes the issue.

Fixes #871.
