### PR TITLE
Change default language server for erlang

### DIFF
--- a/rc/servers.kak
+++ b/rc/servers.kak
@@ -124,10 +124,9 @@ hook -group lsp-filetype-elvish global BufSetOption filetype=elvish %{
 
 hook -group lsp-filetype-erlang global BufSetOption filetype=erlang %{
     set-option buffer lsp_servers %{
-        [erlang_ls]
+        [elp]
         root_globs = ["rebar.config", "erlang.mk", ".git", ".hg"]
-        # See https://github.com/erlang-ls/erlang_ls.git for more information and
-        # how to configure. This default config should work in most cases though.
+        args = [ "server" ]
     }
 }
 


### PR DESCRIPTION
`erlang_ls` has been [archived](https://github.com/erlang-ls/erlang_ls/commit/3a791859ef6a9216f96b8a1f19b38be6d8ba51d3) and it is recomend to use [`erlang-language-platform`](https://github.com/whatsapp/erlang-language-platform) now