### PR TITLE
fix(ci/commit-new-release.sh): interpolate version number

### DIFF
--- a/ci/commit-new-release.sh
+++ b/ci/commit-new-release.sh
@@ -71,7 +71,7 @@ binary x86_64-unknown-linux-musl
 	class KakouneLsp < Formula
 	  desc "Kakoune Language Server Protocol Client"
 	  homepage "https://github.com/kakoune-lsp/kakoune-lsp/"
-	  version "18.2.0"
+	  version "$new"
 
 	  if Hardware::CPU.arm?
 	    url "${aarch64_apple_darwin_url}"


### PR DESCRIPTION
The version in `ci/commit-new-release.sh` is currently hardcoded to 18.2.0 ([link](https://github.com/kakoune-lsp/kakoune-lsp/blob/2f28e35021358b590304687f1ea947fb60714bf4/ci/commit-new-release.sh#L74)). This is causing [kakoune-lsp/homebrew-kakoune-lsp](https://github.com/kakoune-lsp/homebrew-kakoune-lsp) to be out of sync.

`brew reinstall kakoune-lsp/kakoune-lsp/kakoune-lsp && kak-lsp --version` correctly shows 19.0.1 but the formula is still at 18.2.0. Assuming the usage is `./ci/commit-new-release.sh 1.2.3`, this fix seemed to do the trick.
