### PR TITLE
Add support for `metals/status` LSP extension

### DIFF
--- a/rc/servers.kak
+++ b/rc/servers.kak
@@ -610,7 +610,7 @@ hook -group lsp-filetype-scala global BufSetOption filetype=scala %{
         [metals.settings.metals]
         icons = "none"
         isHttpEnabled = true
-        statusBarProvider = "show-message"
+        statusBarProvider = "on"
         compilerOptions = { overrideDefFormat = "ascii" }
         inlayHints.hintsInPatternMatch.enable = true
         inlayHints.implicitArguments.enable = true

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -2112,6 +2112,9 @@ fn dispatch_server_notification(
         "telemetry/event" => {
             debug!(ctx.to_editor(), "{:?}", params);
         }
+        "metals/status" => {
+            metals::status(server_id, meta, params, ctx);
+        }
         _ => {
             warn!(ctx.to_editor(), "Unsupported method: {}", method);
         }

--- a/src/language_features/metals.rs
+++ b/src/language_features/metals.rs
@@ -1,0 +1,57 @@
+use jsonrpc_core::Params;
+
+use crate::{context::Context, editor_quote, EditorMeta, ServerId, LAST_CLIENT};
+
+/// https://scalameta.org/metals/docs/integrations/new-editor#metalsstatus
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MetalsStatusParams {
+    /// The text to display in the status bar.
+    pub text: String,
+    /// If true, show the status bar.
+    pub show: Option<bool>,
+    /// If true, hide the status bar.
+    pub hide: Option<bool>,
+    /// If set, display this message when user hovers over the status bar.
+    pub tooltip: Option<String>,
+    /// If set, execute this command when the user clicks on the status bar item.
+    pub command: Option<String>,
+}
+
+/// Maps 'metals/status' to 'lsp-show-message-info'.
+/// Doesn't support the 'command' parameter as it's not clear how to action on the notification.
+pub fn status(server_id: ServerId, meta: EditorMeta, params: Params, ctx: &mut Context) {
+    let params: MetalsStatusParams = params.parse().expect("Failed to parse semhl params");
+
+    let show = params.show.unwrap_or(false) && !params.hide.unwrap_or(false);
+
+    if show {
+        let have_client = meta.client.is_some();
+        let last_client = LAST_CLIENT.lock().unwrap();
+        let client = if have_client {
+            ""
+        } else {
+            &last_client
+                .as_ref()
+                .map(|client| client.as_str())
+                .unwrap_or_default()
+        };
+        let msg = format!(
+            "{}{}",
+            params.text,
+            params
+                .tooltip
+                .map(|tooltip| format!(": {}", tooltip))
+                .unwrap_or("".to_string())
+        );
+
+        ctx.exec(
+            meta,
+            format!(
+                "evaluate-commands -verbatim -try-client '{}' lsp-show-message-info {} {}",
+                client,
+                editor_quote(&ctx.server(server_id).name),
+                editor_quote(&msg)
+            ),
+        );
+    }
+}

--- a/src/language_features/mod.rs
+++ b/src/language_features/mod.rs
@@ -13,6 +13,7 @@ pub mod highlight;
 pub mod hover;
 pub mod inlay_hints;
 pub mod lean;
+pub mod metals;
 pub mod range_formatting;
 pub mod rename;
 pub mod rust_analyzer;


### PR DESCRIPTION
# Metals LSP extensions
Editor clients can opt into receiving Metals-specific JSON-RPC requests and notifications. Metals extensions are not defined in LSP and are not strictly required for the Metals server to function but it is recommended to implement them to improve the user experience.

See:
https://scalameta.org/metals/docs/integrations/new-editor#metalsstatus

## `metals/status`
The Metals status notification is sent from the server to the client to notify about non-critical and non-actionable events that are happening in the server. Metals status notifications are a complement to `window/showMessage` and `window/logMessage`.
Unlike `window/logMessage`, status notifications should always be visible in the user interface.
Unlike `window/showMessage`, status notifications are not critical meaning that they should not demand too much attention from the user.

In general, Metals uses status notifications to update the user about ongoing events in the server such as batch compilation in the build server or when a successful connection was established with the build server.