### PR TITLE
servers.kak: update markdown-oxide root markers (example config)

### DIFF
--- a/rc/servers.kak
+++ b/rc/servers.kak
@@ -434,7 +434,7 @@ hook -group lsp-filetype-markdown global BufSetOption filetype=markdown %{
     # }
     # set-option buffer lsp_servers %{
     #     [markdown-oxide]
-    #     root_globs = ["logseq"]
+    #     root_globs = [".moxide.toml", ".obsidian", "logseq"]
     # }
 }
 


### PR DESCRIPTION
The commented-out markdown-oxide configuration in servers.kak
currently uses `root_globs = ["logseq"]`, which only matches
Logseq workspaces.

markdown-oxide supports a wider range of setups. This adds:
- `.moxide.toml` - markdown-oxide project config file
- `.obsidian` - Obsidian vault marker (most common use case)

`logseq` is kept for backward compatibility with the original intent.

`.git`/`.hg` are intentionally not included as they would make any
git repository a potential vault, which may increase indexing cost.