### PR TITLE
completion: support server-defined triggerCharacters

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -128,6 +128,7 @@ declare-option -docstring "Completion request is sent only when this expression 
 # By default, it tracks back to the first punctuation or whitespace.
 declare-option -docstring "Select from cursor to the start of the term being completed" str lsp_completion_fragment_start %{execute-keys "<esc><a-h>s\$?[\w%opt{lsp_extra_word_chars}]+.\z<ret>"}
 declare-option -hidden str lsp_extra_word_chars
+declare-option -hidden str lsp_completion_trigger_regex
 # Update lsp_extra_word_chars whenever extra_word_chars changes.
 # We could avoid this if we are not enabled, but this doesn't trigger that often and that would complicate initialization.
 hook -group lsp-extra-word-chars global WinSetOption extra_word_chars=.* %{
@@ -698,25 +699,40 @@ define-command -hidden lsp-did-change -docstring "Notify language server about b
 }
 
 define-command -hidden lsp-completion -docstring "Request completions for the main cursor position" %{
+    declare-option -hidden str lsp_completion_offset
+    declare-option -hidden str lsp_trigger_character
+
+    set-option window lsp_trigger_character ''
+    set-option window lsp_completion_offset %val{cursor_column}
+
     try %{
-        # Fail if preceding character is a whitespace (by default; the trigger could be customized).
-        evaluate-commands -draft %opt{lsp_completion_trigger}
-
-        # Kakoune requires completions to point fragment start rather than cursor position.
-        # We try to detect it and put into lsp_completion_offset and then pass via completion.offset
-        # parameter to the kakoune-lsp server so it can use it when sending completions back.
-        declare-option -hidden str lsp_completion_offset
-
-        set-option window lsp_completion_offset %val{cursor_column}
-        evaluate-commands -draft %{
-            try %{
-                evaluate-commands %opt{lsp_completion_fragment_start}
-                set-option window lsp_completion_offset %val{cursor_column}
+        try %{
+            # Path 1: Trigger character detection
+            # In insert mode, <a-h> selects the line including trailing newline.
+            # <a-k> keeps the selection only if it ends with a trigger char
+            # before the newline; on success we extract it with <a-:> (ensure
+            # forward), ; (reduce to cursor at the trailing newline), h (back
+            # one character to the trigger char).
+            evaluate-commands -draft %{
+                execute-keys "<a-h><a-k>[%opt{lsp_completion_trigger_regex}]\n\z<ret>"
+                execute-keys "<a-:>;h"
+                set-option window lsp_trigger_character %val{selection}
+            }
+        } catch %{
+            # Path 2: Normal completion (no trigger character or no match)
+            # Standard trigger check (default: preceding character is not whitespace).
+            evaluate-commands -draft %opt{lsp_completion_trigger}
+            # Detect fragment start position.
+            evaluate-commands -draft %{
+                try %{
+                    evaluate-commands %opt{lsp_completion_fragment_start}
+                    set-option window lsp_completion_offset %val{cursor_column}
+                }
             }
         }
 
         lsp-send textDocument/completion %val{cursor_line} %val{cursor_column} \
-            %opt{lsp_completion_offset}
+            %opt{lsp_completion_offset} %opt{lsp_trigger_character}
     }
 }
 

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -10,6 +10,7 @@ use lsp_types::notification::*;
 use lsp_types::request::*;
 use lsp_types::*;
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::process;
@@ -175,7 +176,7 @@ pub fn initialize(meta: EditorMeta, ctx: &mut Context, servers: Vec<ServerId>) {
                                         CompletionItemKind::TYPE_PARAMETER,
                                     ]),
                                 }),
-                                context_support: Some(false),
+                                context_support: Some(true),
                                 insert_text_mode: None,
                                 completion_list: None,
                             }),
@@ -408,7 +409,7 @@ pub fn initialize(meta: EditorMeta, ctx: &mut Context, servers: Vec<ServerId>) {
         })
         .collect();
 
-    ctx.call::<Initialize, _>(meta, RequestParams::Each(req_params), move |ctx, _meta, results| {
+    ctx.call::<Initialize, _>(meta, RequestParams::Each(req_params), move |ctx, meta, results| {
         let results: HashMap<_,_> = results.into_iter().collect();
 
         let to_editor = ctx.to_editor().clone();
@@ -445,8 +446,45 @@ pub fn initialize(meta: EditorMeta, ctx: &mut Context, servers: Vec<ServerId>) {
                 ctx.notify::<Initialized>(server_id, InitializedParams {});
             }
         }
+        send_completion_trigger_characters(&meta, ctx);
         controller::dispatch_pending_editor_requests(ctx)
     });
+}
+
+pub fn send_completion_trigger_characters(meta: &EditorMeta, ctx: &Context) {
+    let mut trigger_chars = BTreeSet::new();
+    for &server_id in &meta.servers {
+        let server = ctx.server(server_id);
+        if let Some(caps) = &server.capabilities {
+            if let Some(provider) = &caps.completion_provider {
+                if let Some(chars) = &provider.trigger_characters {
+                    for ch in chars {
+                        if ch.chars().count() == 1 {
+                            trigger_chars.insert(ch.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let escaped: String = trigger_chars
+        .iter()
+        .map(|ch| match ch.as_str() {
+            "-" => "\\-".to_string(),
+            "<" => "<lt>".to_string(),
+            "[" => "\\[".to_string(),
+            "\\" => "\\\\".to_string(),
+            "]" => "\\]".to_string(),
+            "^" => "\\^".to_string(),
+            other => other.to_string(),
+        })
+        .collect();
+    let command = format!(
+        "evaluate-commands -buffer {} -verbatim -- set-option buffer lsp_completion_trigger_regex {}",
+        editor_quote(&meta.buffile),
+        editor_quote(&escaped),
+    );
+    ctx.exec(meta.clone(), command);
 }
 
 pub const CAPABILITY_CALL_HIERARCHY: &str = "lsp-incoming-calls, lsp-outgoing-calls";

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -524,6 +524,14 @@ fn dispatch_fifo_request(
             position: state.next()?,
             completion: EditorCompletion {
                 offset: state.next()?,
+                trigger_character: {
+                    let tc: String = state.next()?;
+                    if tc.is_empty() {
+                        None
+                    } else {
+                        Some(tc)
+                    }
+                },
             },
         }),
         "textDocument/definition" => {

--- a/src/language_features/completion.rs
+++ b/src/language_features/completion.rs
@@ -31,6 +31,18 @@ pub fn text_document_completion(
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, server_settings)| {
+            let context = params.completion.trigger_character.as_ref().and_then(|tc| {
+                let has_trigger = server_settings
+                    .capabilities
+                    .as_ref()
+                    .and_then(|caps| caps.completion_provider.as_ref())
+                    .and_then(|provider| provider.trigger_characters.as_ref())
+                    .is_some_and(|chars| chars.contains(tc));
+                has_trigger.then(|| CompletionContext {
+                    trigger_kind: CompletionTriggerKind::TRIGGER_CHARACTER,
+                    trigger_character: Some(tc.clone()),
+                })
+            });
             (
                 server_id,
                 vec![CompletionParams {
@@ -46,7 +58,7 @@ pub fn text_document_completion(
                         )
                         .unwrap(),
                     },
-                    context: None,
+                    context,
                     work_done_progress_params: Default::default(),
                     partial_result_params: Default::default(),
                 }],

--- a/src/language_features/completion.rs
+++ b/src/language_features/completion.rs
@@ -254,10 +254,11 @@ fn editor_completion(
                     editor_quote(&snippet)
                 );
 
-                completion_entry(&insert_text, &on_select, &entry)
+                // Use filterText when available for Kakoune filtering, falling back
+                // to the processed insert text.
+                let candidate_text = x.filter_text.as_deref().unwrap_or(&insert_text);
+                completion_entry(candidate_text, &on_select, &entry)
             } else {
-                // Due to implementation reasons, we currently do not support filter text
-                // with snippets.
                 let specified_filter_text = x.filter_text.as_ref().unwrap_or(&x.label);
                 let (insert_text, on_select) = if specified_filter_text != eventual_insert_text {
                     // Simulate filter-text support by giving the filter-text to Kakoune

--- a/src/text_sync.rs
+++ b/src/text_sync.rs
@@ -4,6 +4,7 @@ use std::{
     time::Duration,
 };
 
+use crate::capabilities::send_completion_trigger_characters;
 use crate::thread_worker::Worker;
 use crate::types::*;
 use crate::{context::*, editor_transport::ToEditorSender};
@@ -42,6 +43,7 @@ pub fn text_document_did_open(
     for &server_id in &meta.servers {
         ctx.notify::<DidOpenTextDocument>(server_id, params.clone());
     }
+    send_completion_trigger_characters(&meta, ctx);
 }
 
 pub fn text_document_did_change(

--- a/src/types.rs
+++ b/src/types.rs
@@ -392,6 +392,7 @@ pub type ServerId = usize;
 #[derive(Debug)]
 pub struct EditorCompletion {
     pub offset: u32,
+    pub trigger_character: Option<String>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Closes #882.

## Summary

When an LSP server registers `triggerCharacters` in its completion capabilities,
kakoune-lsp now detects them and fires completion requests accordingly, with
proper `CompletionContext` sent to each server.

### Changes

1. **Kakoune script** (`rc/lsp.kak`):
   - `lsp-completion` now has two paths:
     - **Path 1**: If the character before the cursor matches one of the
       server's trigger characters (`lsp_completion_trigger_regex`), fire a
       completion request immediately, bypassing `lsp_completion_trigger`.
       This handles whitespace triggers and non-word triggers like `(`, `[`, etc.
     - **Path 2** (fallback): The existing `lsp_completion_trigger` /
       `lsp_completion_fragment_start` logic, unchanged.
   - Trigger character extraction uses `<a-k>` as a guard (keeping the
     selection only if the line ends with a trigger character) followed by
     cursor movement (`<a-:>;h`) to isolate the character. This avoids shell
     subprocess spawning on the `InsertIdle` hot path.
   - The trigger character is passed to the Rust side via the FIFO.

2. **Rust side**:
   - `send_completion_trigger_characters()` extracts trigger characters from all
     servers' capabilities and sets `lsp_completion_trigger_regex` (the union,
     in a `BTreeSet` for dedup).
   - Per-server `CompletionContext` with `TriggerCharacter` kind is sent only to
     servers that actually registered the trigger character.
   - `context_support: true` is now advertised in client capabilities.

3. **filterText for snippet completions** (`completion.rs`):
   - Snippet completions now use `filter_text` (if provided by the server)
     instead of the `insert_text` for Kakoune's completion filtering. This
     fixes cases where the filter text differs from the snippet body.

### Design decisions

- **InsertIdle, not InsertChar**: Per maintainer guidance, InsertIdle is kept
  to avoid issues with pasting in insert mode.
- **Union of trigger chars**: Multi-server trigger characters are unioned.
  Per-server filtering happens on the Rust side when constructing
  `CompletionContext`.
- **No `Invoked` kind**: Kakoune has no concept of manual completion invocation.

### Test plan

- With markdown-oxide: `[title](` now triggers file path completions
- With rust-analyzer: `.` triggers method completions with `CompletionContext`
- Non-trigger characters still use the existing completion path
- Multiple LSP servers in the same buffer work correctly (each gets context
  only for its own trigger characters)
