### PR TITLE
Encode brackets for file paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,15 +1187,15 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lsp-types"
-version = "0.95.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
 dependencies = [
  "bitflags 1.3.2",
+ "fluent-uri",
  "serde",
  "serde_json",
  "serde_repr",
- "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ itertools = "0.13.0"
 jsonrpc-core = "18.0.0"
 lazy_static = "1.5.0"
 libc = "0.2.155"
-lsp-types = { version = "0.95.0", features = ["proposed"] }
+lsp-types = { version = "0.97.0", features = ["proposed"] }
 mio = { version = "1.0.2", features = ["os-ext"] }
 notify-debouncer-full = "0.3.1"
 pulldown-cmark = "0.9.2"

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -3,6 +3,7 @@ use crate::controller;
 use crate::settings::initialization_options;
 use crate::settings::record_dynamic_config;
 use crate::types::*;
+use crate::util::file_path_to_uri;
 use crate::util::*;
 use indoc::formatdoc;
 use itertools::Itertools;
@@ -13,7 +14,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::process;
-use url::Url;
 
 pub fn initialize(meta: EditorMeta, ctx: &mut Context, servers: Vec<ServerId>) {
     #[allow(deprecated)]
@@ -64,6 +64,7 @@ pub fn initialize(meta: EditorMeta, ctx: &mut Context, servers: Vec<ServerId>) {
                 server_id,
                 vec![InitializeParams {
                     capabilities: ClientCapabilities {
+                        notebook_document: None,
                         workspace: Some(WorkspaceClientCapabilities {
                             apply_edit: Some(true),
                             workspace_edit: Some(WorkspaceEditClientCapabilities {
@@ -388,11 +389,11 @@ pub fn initialize(meta: EditorMeta, ctx: &mut Context, servers: Vec<ServerId>) {
                     },
                     initialization_options: initialization_options[idx].clone(),
                     process_id: Some(process::id()),
-                    root_uri: Some(Url::from_file_path(&roots[0]).unwrap()),
+                    root_uri: Some(file_path_to_uri(&roots[0])),
                     root_path: Some(roots[0].clone()),
                     trace: Some(TraceValue::Off),
                     workspace_folders: Some(vec![WorkspaceFolder {
-                        uri: Url::from_file_path(&roots[0]).unwrap(),
+                        uri: file_path_to_uri(&roots[0]),
                         name: roots[0].clone(),
                     }]),
                     client_info: Some(ClientInfo {

--- a/src/language_features/clangd.rs
+++ b/src/language_features/clangd.rs
@@ -8,7 +8,7 @@ pub struct SwitchSourceHeaderRequest {}
 
 impl Request for SwitchSourceHeaderRequest {
     type Params = TextDocumentIdentifier;
-    type Result = Option<Url>;
+    type Result = Option<Uri>;
     const METHOD: &'static str = "textDocument/switchSourceHeader";
 }
 
@@ -20,7 +20,7 @@ pub fn switch_source_header(meta: EditorMeta, ctx: &mut Context) {
             (
                 server_id,
                 vec![TextDocumentIdentifier {
-                    uri: Url::from_file_path(&meta.buffile).unwrap(),
+                    uri: file_path_to_uri(&meta.buffile),
                 }],
             )
         })
@@ -38,7 +38,7 @@ pub fn switch_source_header(meta: EditorMeta, ctx: &mut Context) {
             if let Some(response) = response {
                 let command = format!(
                     "evaluate-commands -try-client %opt{{jumpclient}} -verbatim -- edit -existing {}",
-                    editor_quote(response.to_file_path().unwrap().to_str().unwrap()),
+                    editor_quote(response.as_str()),
                 );
                 ctx.exec(meta, command);
             }

--- a/src/language_features/code_action.rs
+++ b/src/language_features/code_action.rs
@@ -16,7 +16,6 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use lsp_types::request::*;
 use lsp_types::*;
-use url::Url;
 
 pub fn text_document_code_action(
     meta: EditorMeta,
@@ -91,7 +90,7 @@ fn code_actions_for_ranges(
                 *server_id,
                 vec![CodeActionParams {
                     text_document: TextDocumentIdentifier {
-                        uri: Url::from_file_path(&meta.buffile).unwrap(),
+                        uri: file_path_to_uri(&meta.buffile),
                     },
                     range: *range,
                     context: CodeActionContext {

--- a/src/language_features/code_lens.rs
+++ b/src/language_features/code_lens.rs
@@ -8,6 +8,7 @@ use crate::position::*;
 use crate::types::*;
 use crate::util::editor_quote;
 use crate::util::escape_tuple_element;
+use crate::util::file_path_to_uri;
 use crate::wcwidth;
 use crate::{capabilities::server_has_capability, markup::escape_kakoune_markup};
 use indoc::formatdoc;
@@ -32,7 +33,7 @@ pub fn text_document_code_lens(meta: EditorMeta, ctx: &mut Context) {
                 server_id,
                 vec![CodeLensParams {
                     text_document: TextDocumentIdentifier {
-                        uri: Url::from_file_path(&meta.buffile).unwrap(),
+                        uri: file_path_to_uri(&meta.buffile),
                     },
                     work_done_progress_params: WorkDoneProgressParams::default(),
                     partial_result_params: PartialResultParams::default(),

--- a/src/language_features/completion.rs
+++ b/src/language_features/completion.rs
@@ -16,7 +16,6 @@ use regex::Regex;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use unicode_width::UnicodeWidthStr;
-use url::Url;
 
 pub fn text_document_completion(
     meta: EditorMeta,
@@ -36,7 +35,7 @@ pub fn text_document_completion(
                 vec![CompletionParams {
                     text_document_position: TextDocumentPositionParams {
                         text_document: TextDocumentIdentifier {
-                            uri: Url::from_file_path(&meta.buffile).unwrap(),
+                            uri: file_path_to_uri(&meta.buffile),
                         },
                         position: get_lsp_position(
                             server_settings,
@@ -350,7 +349,7 @@ pub fn completion_item_resolve(
         match item.additional_text_edits {
             Some(edits) if !edits.is_empty() => {
                 // Not sure if this case ever happens, the spec is unclear.
-                let uri = Url::from_file_path(&meta.buffile).unwrap();
+                let uri = file_path_to_uri(&meta.buffile);
                 apply_text_edits(server_id, meta, uri, edits, ctx);
                 return;
             }
@@ -404,7 +403,7 @@ fn editor_completion_item_resolve(
             ),
         );
     } else if let Some(resolved_edits) = new_item.additional_text_edits {
-        let uri = Url::from_file_path(&meta.buffile).unwrap();
+        let uri = file_path_to_uri(&meta.buffile);
         apply_text_edits(server_id, meta, uri, resolved_edits.clone(), ctx)
     }
 }

--- a/src/language_features/eclipse_jdt_ls.rs
+++ b/src/language_features/eclipse_jdt_ls.rs
@@ -1,12 +1,13 @@
 use super::code_action::apply_workspace_edit_editor_command;
 use crate::context::*;
 use crate::types::*;
+use crate::util::file_path_to_uri;
 use lsp_types::request::ExecuteCommand;
 use lsp_types::*;
 
 pub fn organize_imports(meta: EditorMeta, ctx: &mut Context) {
-    let file_uri = Url::from_file_path(&meta.buffile).unwrap();
-    let file_uri: String = file_uri.into();
+    let file_uri = file_path_to_uri(&meta.buffile);
+    let file_uri: String = file_uri.as_str().into();
 
     let req_params = ctx
         .servers(&meta)

--- a/src/language_features/formatting.rs
+++ b/src/language_features/formatting.rs
@@ -5,10 +5,10 @@ use crate::context::*;
 use crate::controller::can_serve;
 use crate::types::*;
 use crate::util::editor_quote;
+use crate::util::file_path_to_uri;
 use itertools::Itertools;
 use lsp_types::request::*;
 use lsp_types::*;
-use url::Url;
 
 pub fn text_document_formatting(
     meta: EditorMeta,
@@ -61,7 +61,7 @@ pub fn text_document_formatting(
         server_id,
         vec![DocumentFormattingParams {
             text_document: TextDocumentIdentifier {
-                uri: Url::from_file_path(&meta.buffile).unwrap(),
+                uri: file_path_to_uri(&meta.buffile),
             },
             options: params.clone(),
             work_done_progress_params: Default::default(),

--- a/src/language_features/highlight.rs
+++ b/src/language_features/highlight.rs
@@ -7,12 +7,12 @@ use crate::types::{
     PositionParams, ServerId,
 };
 use crate::util::editor_quote;
+use crate::util::file_path_to_uri;
 use itertools::Itertools;
 use lsp_types::{
     request::DocumentHighlightRequest, DocumentHighlight, DocumentHighlightKind,
     DocumentHighlightParams, TextDocumentIdentifier, TextDocumentPositionParams,
 };
-use url::Url;
 
 pub fn text_document_highlight(meta: EditorMeta, params: PositionParams, ctx: &mut Context) {
     let eligible_servers: Vec<_> = ctx
@@ -34,7 +34,7 @@ pub fn text_document_highlight(meta: EditorMeta, params: PositionParams, ctx: &m
                 vec![DocumentHighlightParams {
                     text_document_position_params: TextDocumentPositionParams {
                         text_document: TextDocumentIdentifier {
-                            uri: Url::from_file_path(&meta.buffile).unwrap(),
+                            uri: file_path_to_uri(&meta.buffile),
                         },
                         position: get_lsp_position(
                             server_settings,

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -9,11 +9,11 @@ use crate::markup::*;
 use crate::mkfifo;
 use crate::position::*;
 use crate::types::*;
+use crate::util::file_path_to_uri;
 use indoc::formatdoc;
 use itertools::Itertools;
 use lsp_types::request::*;
 use lsp_types::*;
-use url::Url;
 
 pub fn text_document_hover(meta: EditorMeta, params: EditorHoverParams, ctx: &mut Context) {
     let eligible_servers: Vec<_> = ctx
@@ -39,7 +39,7 @@ pub fn text_document_hover(meta: EditorMeta, params: EditorHoverParams, ctx: &mu
                 vec![HoverParams {
                     text_document_position_params: TextDocumentPositionParams {
                         text_document: TextDocumentIdentifier {
-                            uri: Url::from_file_path(&meta.buffile).unwrap(),
+                            uri: file_path_to_uri(&meta.buffile),
                         },
                         position: get_lsp_position(server_settings, &meta.buffile, &cursor, ctx)
                             .unwrap(),

--- a/src/language_features/inlay_hints.rs
+++ b/src/language_features/inlay_hints.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::HashMap};
 use itertools::Itertools;
 use lsp_types::{
     request::InlayHintRequest, InlayHint, InlayHintLabel, InlayHintParams, Position, Range,
-    TextDocumentIdentifier, TextEdit, Url,
+    TextDocumentIdentifier, TextEdit,
 };
 
 use crate::{
@@ -15,7 +15,7 @@ use crate::{
     },
     text_edit::apply_text_edits,
     types::{EditorMeta, ServerId},
-    util::{editor_quote, escape_tuple_element},
+    util::{editor_quote, escape_tuple_element, file_path_to_uri},
 };
 
 #[derive(Debug, PartialEq, Clone, Default)]
@@ -40,7 +40,7 @@ pub fn inlay_hints(meta: EditorMeta, params: InlayHintsOptions, ctx: &mut Contex
                 vec![InlayHintParams {
                     work_done_progress_params: Default::default(),
                     text_document: TextDocumentIdentifier {
-                        uri: Url::from_file_path(&meta.buffile).unwrap(),
+                        uri: file_path_to_uri(&meta.buffile),
                     },
                     range: Range::new(Position::new(0, 0), Position::new(params.buf_line_count, 0)),
                 }],
@@ -230,7 +230,7 @@ pub fn inlay_hint_apply(meta: EditorMeta, params: InlayHintApplyParams, ctx: &mu
             continue;
         }
 
-        let uri = Url::from_file_path(&meta.buffile).unwrap();
+        let uri = file_path_to_uri(&meta.buffile);
 
         // FIXME: https://github.com/kakoune-lsp/kakoune-lsp/issues/873
         // we expect this to break if multiple servers provide InlayHints with textedits

--- a/src/language_features/lean.rs
+++ b/src/language_features/lean.rs
@@ -79,7 +79,7 @@ pub fn plain_goal_impl<
                 server_id,
                 vec![R::Params {
                     text_document: TextDocumentIdentifier {
-                        uri: Url::from_file_path(&meta.buffile).unwrap(),
+                        uri: file_path_to_uri(&meta.buffile),
                     },
                     position: get_lsp_position(
                         server_settings,

--- a/src/language_features/range_formatting.rs
+++ b/src/language_features/range_formatting.rs
@@ -7,10 +7,10 @@ use crate::position::{kakoune_range_to_lsp, parse_kakoune_range};
 use crate::text_edit::{apply_text_edits_to_buffer, TextEditish};
 use crate::types::*;
 use crate::util::editor_quote;
+use crate::util::file_path_to_uri;
 use itertools::Itertools;
 use lsp_types::request::*;
 use lsp_types::*;
-use url::Url;
 
 pub fn text_document_range_formatting(
     meta: EditorMeta,
@@ -80,7 +80,7 @@ pub fn text_document_range_formatting(
             })
             .map(|range| DocumentRangeFormattingParams {
                 text_document: TextDocumentIdentifier {
-                    uri: Url::from_file_path(&meta.buffile).unwrap(),
+                    uri: file_path_to_uri(&meta.buffile),
                 },
                 range,
                 options: params.formatting_options.clone(),

--- a/src/language_features/rename.rs
+++ b/src/language_features/rename.rs
@@ -1,10 +1,10 @@
 use crate::context::*;
 use crate::position::*;
 use crate::types::*;
+use crate::util::file_path_to_uri;
 
 use lsp_types::request::*;
 use lsp_types::*;
-use url::Url;
 
 use super::super::workspace;
 
@@ -17,7 +17,7 @@ pub fn text_document_rename(meta: EditorMeta, params: TextDocumentRenameParams, 
                 vec![RenameParams {
                     text_document_position: TextDocumentPositionParams {
                         text_document: TextDocumentIdentifier {
-                            uri: Url::from_file_path(&meta.buffile).unwrap(),
+                            uri: file_path_to_uri(&meta.buffile),
                         },
                         position: get_lsp_position(
                             server_settings,

--- a/src/language_features/selection_range.rs
+++ b/src/language_features/selection_range.rs
@@ -1,11 +1,11 @@
 use crate::context::*;
 use crate::position::*;
 use crate::types::*;
+use crate::util::file_path_to_uri;
 use indoc::formatdoc;
 use itertools::Itertools;
 use lsp_types::request::*;
 use lsp_types::*;
-use url::Url;
 
 pub fn text_document_selection_range(
     meta: EditorMeta,
@@ -47,7 +47,7 @@ pub fn text_document_selection_range(
                 server_id,
                 vec![SelectionRangeParams {
                     text_document: TextDocumentIdentifier {
-                        uri: Url::from_file_path(&meta.buffile).unwrap(),
+                        uri: file_path_to_uri(&meta.buffile),
                     },
                     positions: cursor_positions,
                     work_done_progress_params: WorkDoneProgressParams::default(),

--- a/src/language_features/semantic_tokens.rs
+++ b/src/language_features/semantic_tokens.rs
@@ -4,13 +4,13 @@ use crate::position::lsp_range_to_kakoune;
 use crate::semantic_tokens_config;
 use crate::types::{EditorMeta, ForwardKakouneRange, ServerId};
 use crate::util::editor_quote;
+use crate::util::file_path_to_uri;
 use lsp_types::request::SemanticTokensFullRequest;
 use lsp_types::{
     Position, Range, SemanticToken, SemanticTokenModifier, SemanticTokensOptions,
     SemanticTokensParams, SemanticTokensRegistrationOptions, SemanticTokensResult,
     SemanticTokensServerCapabilities::*, TextDocumentIdentifier,
 };
-use url::Url;
 
 pub fn tokens_request(meta: EditorMeta, ctx: &mut Context) {
     let eligible_servers: Vec<_> = ctx
@@ -32,7 +32,7 @@ pub fn tokens_request(meta: EditorMeta, ctx: &mut Context) {
                 vec![SemanticTokensParams {
                     partial_result_params: Default::default(),
                     text_document: TextDocumentIdentifier {
-                        uri: Url::from_file_path(&meta.buffile).unwrap(),
+                        uri: file_path_to_uri(&meta.buffile),
                     },
                     work_done_progress_params: Default::default(),
                 }],

--- a/src/language_features/signature_help.rs
+++ b/src/language_features/signature_help.rs
@@ -8,7 +8,6 @@ use crate::util::*;
 use lsp_types::request::*;
 use lsp_types::*;
 use ropey::Rope;
-use url::Url;
 
 pub fn text_document_signature_help(meta: EditorMeta, params: PositionParams, ctx: &mut Context) {
     let eligible_servers: Vec<_> = ctx
@@ -31,7 +30,7 @@ pub fn text_document_signature_help(meta: EditorMeta, params: PositionParams, ct
                     context: None,
                     text_document_position_params: TextDocumentPositionParams {
                         text_document: TextDocumentIdentifier {
-                            uri: Url::from_file_path(&meta.buffile).unwrap(),
+                            uri: file_path_to_uri(&meta.buffile),
                         },
                         position: get_lsp_position(
                             server_settings,

--- a/src/language_features/texlab.rs
+++ b/src/language_features/texlab.rs
@@ -5,11 +5,11 @@ use crate::capabilities::{
 use crate::context::{Context, RequestParams};
 use crate::position::get_lsp_position;
 use crate::types::EditorMeta;
+use crate::util::file_path_to_uri;
 use crate::PositionParams;
 use lsp_types::request::Request;
 use lsp_types::TextDocumentIdentifier;
 use lsp_types::TextDocumentPositionParams;
-use lsp_types::Url;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::fmt;
@@ -68,7 +68,7 @@ pub fn forward_search(meta: EditorMeta, params: PositionParams, ctx: &mut Contex
                 server_id,
                 vec![TextDocumentPositionParams {
                     text_document: TextDocumentIdentifier {
-                        uri: Url::from_file_path(&meta.buffile).unwrap(),
+                        uri: file_path_to_uri(&meta.buffile),
                     },
                     position: get_lsp_position(
                         server_settings,
@@ -152,7 +152,7 @@ pub fn build(meta: EditorMeta, ctx: &mut Context) {
                 server_id,
                 vec![BuildTextDocumentParams {
                     text_document: TextDocumentIdentifier {
-                        uri: Url::from_file_path(&meta.buffile).unwrap(),
+                        uri: file_path_to_uri(&meta.buffile),
                     },
                 }],
             )

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,8 @@
 use crate::types::*;
+use lsp_types::Uri;
 use std::os::unix::fs::DirBuilderExt;
+use std::path::PathBuf;
+use std::str::FromStr;
 use std::{collections::HashMap, path::Path};
 use std::{env, fs, io, path};
 
@@ -126,4 +129,19 @@ where
         .ok()
         .and_then(|p| p.to_str())
         .unwrap_or(target)
+}
+
+/// Convert a filesystem path to a file:// URI.
+pub fn file_path_to_uri(path: &str) -> Uri {
+    let url = url::Url::from_file_path(path).unwrap();
+    let s = url.as_str().replace('[', "%5B").replace(']', "%5D");
+    Uri::from_str(&s).unwrap()
+}
+
+/// Parse a file:// URI and return the filesystem path.
+pub fn uri_to_file_path(uri: &Uri) -> PathBuf {
+    url::Url::parse(uri.as_str())
+        .ok()
+        .and_then(|url| url.to_file_path().ok())
+        .unwrap_or_else(|| PathBuf::from(uri.path().as_str()))
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -4,6 +4,7 @@ use crate::language_features::{document_symbol, rust_analyzer};
 use crate::settings::*;
 use crate::text_edit::apply_text_edits_try_deferred;
 use crate::types::*;
+use crate::util::uri_to_file_path;
 use crate::util::*;
 use jsonrpc_core::Params;
 use lsp_types::notification::*;
@@ -138,7 +139,7 @@ impl document_symbol::Symbol<WorkspaceSymbol> for WorkspaceSymbol {
     fn kind(&self) -> SymbolKind {
         self.kind
     }
-    fn uri(&self) -> Option<&Url> {
+    fn uri(&self) -> Option<&Uri> {
         None
     }
     fn range(&self) -> Range {
@@ -264,7 +265,7 @@ pub fn execute_command(
 pub fn apply_document_resource_op(op: ResourceOp) -> io::Result<()> {
     match op {
         ResourceOp::Create(op) => {
-            let path = op.uri.to_file_path().unwrap();
+            let path = uri_to_file_path(&op.uri);
             let ignore_if_exists = if let Some(options) = op.options {
                 !options.overwrite.unwrap_or(false) && options.ignore_if_exists.unwrap_or(false)
             } else {
@@ -280,7 +281,7 @@ pub fn apply_document_resource_op(op: ResourceOp) -> io::Result<()> {
             }
         }
         ResourceOp::Delete(op) => {
-            let path = op.uri.to_file_path().unwrap();
+            let path = uri_to_file_path(&op.uri);
             if path.is_dir() {
                 let recursive = if let Some(options) = op.options {
                     options.recursive.unwrap_or(false)
@@ -299,8 +300,8 @@ pub fn apply_document_resource_op(op: ResourceOp) -> io::Result<()> {
             }
         }
         ResourceOp::Rename(op) => {
-            let from = op.old_uri.to_file_path().unwrap();
-            let to = op.new_uri.to_file_path().unwrap();
+            let from = uri_to_file_path(&op.old_uri);
+            let to = uri_to_file_path(&op.new_uri);
             let ignore_if_exists = if let Some(options) = op.options {
                 !options.overwrite.unwrap_or(false) && options.ignore_if_exists.unwrap_or(false)
             } else {


### PR DESCRIPTION
Files with brackets in their name were failing due to the lack of encoding. This PR encodes them and uses the new `Uri` struct for `lsp-types`.