### PR TITLE
Add support for Deno virtual documents

### DIFF
--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -2266,10 +2266,15 @@ hook -group lsp-goto global WinSetOption filetype=(lsp-(?:diagnostics|document-s
 define-command -hidden lsp-make-register-relative-to-root %{
     evaluate-commands -save-regs / %{
         try %{
-            # Is it an absolute path?
-            execute-keys <a-k>\A/<ret>
+            # Is it a virtual path?
+            execute-keys <a-k>\A\w+:/<ret>
         } catch %{
-            set-register a "%opt{lsp_project_root}%reg{a}"
+            try %{
+                # Is it an absolute path?
+                execute-keys <a-k>\A/<ret>
+            } catch %{
+                set-register a "%opt{lsp_project_root}%reg{a}"
+            }
         }
     }
 }
@@ -2284,17 +2289,35 @@ define-command -hidden lsp-goto-jump -docstring %{
         try %{
             evaluate-commands -draft -save-regs / %{
                 set-register / ^\h*\K([^:\n]+):(\d+)\b(?::(\d+)\b)?(?::([^\n]+))
-                execute-keys <semicolon>xs<ret>
+                try %{
+                    execute-keys <semicolon>xs<ret>
+                } catch %{
+                    # Try virtual path pattern.
+                    set-register / ^\h*\K(.+):(\d+):(\d+):([^\n]+)
+                    execute-keys <semicolon>xs<ret>
+                }
                 set-register a "%reg{1}"
                 set-register b "%reg{2}"
                 set-register c "%reg{3}"
                 lsp-make-register-relative-to-root
             }
             set-option buffer jump_current_line %val{cursor_line}
-            evaluate-commands -try-client %opt{jumpclient} -verbatim -- edit -existing -- %reg{a} %reg{b} %reg{c}
-            try %{ focus %opt{jumpclient} }
+            try %{
+                lsp-open-file %reg{a} %reg{b} %reg{c}
+            } catch %{
+                lsp-open-virtual-file %reg{a} %reg{b} %reg{c} %reg{b} %reg{c}
+            }
         }
     }
+}
+
+define-command -hidden lsp-open-file -params 3 %{
+    evaluate-commands -try-client %opt{jumpclient} -verbatim -- edit -existing -- %arg{@}
+    try %{ focus %opt{jumpclient} }
+}
+
+define-command -hidden lsp-open-virtual-file -params 5 %{
+    evaluate-commands -try-client %opt{jumpclient} -- lsp-do-send kakoune/open-virtual-file %arg{@}
 }
 
 define-command -hidden lsp-document-symbol-jump -docstring %{

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,6 +2,7 @@ use crate::editor_transport::{self, ToEditorSender};
 use crate::language_server_transport::LanguageServerTransport;
 use crate::text_sync::CompiledFileSystemWatcher;
 use crate::thread_worker::Worker;
+use crate::util::file_path_to_uri;
 use crate::{filetype_to_language_id_map, types::*};
 use jsonrpc_core::{self, Call, Error, Failure, Id, Output, Success, Value, Version};
 use lsp_types::notification::{Cancel, Notification};
@@ -13,6 +14,7 @@ use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::convert::TryInto;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::time;
 
 // Copy of Kakoune's timestamped buffer content.
@@ -78,6 +80,7 @@ pub struct Context {
     pub config: Config,
     pub diagnostics: HashMap<String, Vec<(ServerId, Diagnostic)>>,
     pub documents: HashMap<String, Document>,
+    pub virtual_documents: HashSet<String>,
     pub dynamic_config: DynamicConfig,
     pub inlay_hints: HashMap<String, Vec<(ServerId, InlayHint)>>,
     pub language_servers: BTreeMap<ServerId, ServerSettings>,
@@ -118,6 +121,7 @@ impl Context {
             config,
             diagnostics: Default::default(),
             documents: Default::default(),
+            virtual_documents: Default::default(),
             dynamic_config: DynamicConfig::default(),
             inlay_hints: Default::default(),
             language_servers: BTreeMap::new(),
@@ -419,6 +423,13 @@ impl Context {
         message: impl AsRef<str>,
     ) {
         editor_transport::show_error(&self.to_editor, meta, response_fifo, message);
+    }
+
+    pub fn uri_for_buffer(&self, path: &str) -> Uri {
+        match self.virtual_documents.contains(path) {
+            true => Uri::from_str(path).unwrap(),
+            false => file_path_to_uri(path),
+        }
     }
 
     fn next_batch_id(&mut self) -> BatchNumber {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -21,7 +21,6 @@ use crate::language_features::lean::{
 };
 use crate::language_features::{selection_range, *};
 use crate::log::DEBUG;
-use crate::progress;
 use crate::project_root::find_project_root;
 use crate::show_message::{self, MessageRequestResponse};
 use crate::text_sync::*;
@@ -34,6 +33,7 @@ use crate::workspace::{
 use crate::{context::*, set_logger};
 use crate::{diagnostics, do_cleanup};
 use crate::{language_server_transport, LAST_CLIENT};
+use crate::{progress, util};
 use ccls::{EditorCallParams, EditorInheritanceParams, EditorMemberParams, EditorNavigateParams};
 use code_lens::{text_document_code_lens, CodeLensOptions};
 use crossbeam_channel::{after, never, tick, Receiver, Select, Sender};
@@ -491,6 +491,25 @@ fn dispatch_fifo_request(
             debug!(&state.to_editor, "Applied option change {}", hook_param);
             return Some(());
         }
+        "kakoune/open-virtual-file" => Box::new({
+            let uri: String = state.next()?;
+            let start_line: u32 = state.next()?;
+            let start_column: u32 = state.next()?;
+            let end_line: u32 = state.next().or(Some(start_line))?;
+            let end_column: u32 = state.next().or(Some(start_column))?;
+
+            OpenVirtualFileParams {
+                uri,
+                start: KakounePosition {
+                    line: start_line,
+                    column: start_column,
+                },
+                end: KakounePosition {
+                    line: end_line,
+                    column: end_column,
+                },
+            }
+        }),
         "rust-analyzer/expandMacro" => Box::new(PositionParams {
             position: state.next()?,
         }),
@@ -1329,6 +1348,9 @@ fn route_request(
     if request_method == notification::Exit::METHOD {
         return None;
     }
+    if request_method == "kakoune/open-virtual-file" {
+        return None;
+    }
     if !meta.session.is_empty() && &meta.session != ctx.session() {
         info!(
             ctx.to_editor(),
@@ -1338,7 +1360,7 @@ fn route_request(
         );
         return Some(ControlFlow::Break(()));
     }
-    if !meta.buffile.starts_with('/') {
+    if !meta.buffile.starts_with('/') && !ctx.virtual_documents.contains(&meta.buffile) {
         report_error_no_server_configured(
             ctx,
             meta,
@@ -1653,6 +1675,7 @@ fn dispatch_incoming_editor_request(request: EditorRequest, ctx: &mut Context) -
             // InsertIdle is not triggered while the completion pager is active, so let's
             // smuggle completion-related requests through.
             && method != request::ResolveCompletionItem::METHOD
+            && method != "kakoune/open-virtual-file"
     {
         assert!(request.response_fifo.is_none());
         // Wait for buffer update.
@@ -1838,6 +1861,13 @@ fn dispatch_editor_request(request: EditorRequest, ctx: &mut Context) -> Control
         }
         "kakoune/textDocument/codeLens" => {
             code_lens::resolve_and_perform_code_lens(meta, params.unbox(), ctx);
+        }
+        "kakoune/open-virtual-file" => {
+            let OpenVirtualFileParams { uri, start, end } = params.unbox();
+            if let Some(contents) = ctx.documents.get(&uri) {
+                let range = KakouneRange { start, end };
+                util::open_virtual_file(ctx, meta, &uri, range, &contents.text.to_string());
+            }
         }
         request::Formatting::METHOD => {
             formatting::text_document_formatting(meta, response_fifo, params.unbox(), ctx);
@@ -2136,7 +2166,11 @@ fn ensure_did_open(request: &EditorRequest, ctx: &mut Context) {
         return;
     };
     if !buffile.starts_with('/') {
-        assert_eq!(&request.method, notification::Exit::METHOD);
+        assert!(
+            request.method == notification::Exit::METHOD
+                || &request.method == "kakoune/open-virtual-file"
+                || ctx.virtual_documents.contains(buffile)
+        );
         return;
     }
     if request.method == notification::DidChangeTextDocument::METHOD {

--- a/src/language_features/call_hierarchy.rs
+++ b/src/language_features/call_hierarchy.rs
@@ -9,12 +9,13 @@ use itertools::Itertools;
 use lsp_types::{request::*, *};
 
 pub fn call_hierarchy_prepare(meta: EditorMeta, params: CallHierarchyParams, ctx: &mut Context) {
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = ctx
         .servers(&meta)
         .map(|(server_id, server_settings)| {
             let position =
                 get_lsp_position(server_settings, &meta.buffile, &params.position, ctx).unwrap();
-            let uri = file_path_to_uri(&meta.buffile);
+            let uri = uri.clone();
             (
                 server_id,
                 vec![CallHierarchyPrepareParams {

--- a/src/language_features/ccls.rs
+++ b/src/language_features/ccls.rs
@@ -35,6 +35,7 @@ impl Request for NavigateRequest {
 }
 
 pub fn navigate(meta: EditorMeta, params: EditorNavigateParams, ctx: &mut Context) {
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = ctx
         .servers(&meta)
         .map(|(server_id, server_settings)| {
@@ -42,7 +43,7 @@ pub fn navigate(meta: EditorMeta, params: EditorNavigateParams, ctx: &mut Contex
                 server_id,
                 vec![NavigateParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     position: get_lsp_position(
                         server_settings,
@@ -85,6 +86,7 @@ impl Request for VarsRequest {
 }
 
 pub fn vars(meta: EditorMeta, params: PositionParams, ctx: &mut Context) {
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = ctx
         .servers(&meta)
         .map(|(server_id, server_settings)| {
@@ -92,7 +94,7 @@ pub fn vars(meta: EditorMeta, params: PositionParams, ctx: &mut Context) {
                 server_id,
                 vec![VarsParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     position: get_lsp_position(
                         server_settings,
@@ -147,6 +149,7 @@ impl Request for InheritanceRequest {
 }
 
 pub fn inheritance(meta: EditorMeta, params: EditorInheritanceParams, ctx: &mut Context) {
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = ctx
         .servers(&meta)
         .map(|(server_id, server_settings)| {
@@ -154,7 +157,7 @@ pub fn inheritance(meta: EditorMeta, params: EditorInheritanceParams, ctx: &mut 
                 server_id,
                 vec![InheritanceParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     position: get_lsp_position(
                         server_settings,
@@ -209,6 +212,7 @@ impl Request for CallRequest {
 }
 
 pub fn call(meta: EditorMeta, params: EditorCallParams, ctx: &mut Context) {
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = ctx
         .servers(&meta)
         .map(|(server_id, server_settings)| {
@@ -216,7 +220,7 @@ pub fn call(meta: EditorMeta, params: EditorCallParams, ctx: &mut Context) {
                 server_id,
                 vec![CallParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     position: get_lsp_position(
                         server_settings,
@@ -270,6 +274,7 @@ impl Request for MemberRequest {
 }
 
 pub fn member(meta: EditorMeta, params: EditorMemberParams, ctx: &mut Context) {
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = ctx
         .servers(&meta)
         .map(|(server_id, server_settings)| {
@@ -277,7 +282,7 @@ pub fn member(meta: EditorMeta, params: EditorMemberParams, ctx: &mut Context) {
                 server_id,
                 vec![MemberParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     position: get_lsp_position(
                         server_settings,

--- a/src/language_features/clangd.rs
+++ b/src/language_features/clangd.rs
@@ -13,6 +13,7 @@ impl Request for SwitchSourceHeaderRequest {
 }
 
 pub fn switch_source_header(meta: EditorMeta, ctx: &mut Context) {
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = meta
         .servers
         .iter()
@@ -20,7 +21,7 @@ pub fn switch_source_header(meta: EditorMeta, ctx: &mut Context) {
             (
                 server_id,
                 vec![TextDocumentIdentifier {
-                    uri: file_path_to_uri(&meta.buffile),
+                    uri: uri.clone(),
                 }],
             )
         })

--- a/src/language_features/code_action.rs
+++ b/src/language_features/code_action.rs
@@ -83,6 +83,7 @@ fn code_actions_for_ranges(
         HashMap::new()
     };
 
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = ranges
         .iter()
         .map(|(server_id, range)| {
@@ -90,7 +91,7 @@ fn code_actions_for_ranges(
                 *server_id,
                 vec![CodeActionParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     range: *range,
                     context: CodeActionContext {

--- a/src/language_features/code_lens.rs
+++ b/src/language_features/code_lens.rs
@@ -8,7 +8,6 @@ use crate::position::*;
 use crate::types::*;
 use crate::util::editor_quote;
 use crate::util::escape_tuple_element;
-use crate::util::file_path_to_uri;
 use crate::wcwidth;
 use crate::{capabilities::server_has_capability, markup::escape_kakoune_markup};
 use indoc::formatdoc;
@@ -26,6 +25,7 @@ pub fn text_document_code_lens(meta: EditorMeta, ctx: &mut Context) {
         return;
     }
 
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, _server)| {
@@ -33,7 +33,7 @@ pub fn text_document_code_lens(meta: EditorMeta, ctx: &mut Context) {
                 server_id,
                 vec![CodeLensParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     work_done_progress_params: WorkDoneProgressParams::default(),
                     partial_result_params: PartialResultParams::default(),

--- a/src/language_features/completion.rs
+++ b/src/language_features/completion.rs
@@ -27,6 +27,7 @@ pub fn text_document_completion(
         .filter(|srv| attempt_server_capability(ctx, *srv, &meta, CAPABILITY_COMPLETION))
         .collect();
 
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, server_settings)| {
@@ -35,7 +36,7 @@ pub fn text_document_completion(
                 vec![CompletionParams {
                     text_document_position: TextDocumentPositionParams {
                         text_document: TextDocumentIdentifier {
-                            uri: file_path_to_uri(&meta.buffile),
+                            uri: uri.clone(),
                         },
                         position: get_lsp_position(
                             server_settings,
@@ -349,7 +350,7 @@ pub fn completion_item_resolve(
         match item.additional_text_edits {
             Some(edits) if !edits.is_empty() => {
                 // Not sure if this case ever happens, the spec is unclear.
-                let uri = file_path_to_uri(&meta.buffile);
+                let uri = ctx.uri_for_buffer(&meta.buffile);
                 apply_text_edits(server_id, meta, uri, edits, ctx);
                 return;
             }
@@ -403,7 +404,7 @@ fn editor_completion_item_resolve(
             ),
         );
     } else if let Some(resolved_edits) = new_item.additional_text_edits {
-        let uri = file_path_to_uri(&meta.buffile);
+        let uri = ctx.uri_for_buffer(&meta.buffile);
         apply_text_edits(server_id, meta, uri, resolved_edits.clone(), ctx)
     }
 }

--- a/src/language_features/deno.rs
+++ b/src/language_features/deno.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+
+use itertools::Itertools;
+use lsp_types::{request::Request, Location, TextDocumentIdentifier, Uri};
+use ropey::Rope;
+
+use crate::{
+    context::{Context, Document, RequestParams},
+    language_features::goto::{goto_location, goto_locations},
+    types::{EditorMeta, ServerId},
+};
+
+pub const SCHEME: &str = "deno";
+
+struct VirtualTextDocument {}
+
+#[derive(Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct VirtualTextDocumentParams {
+    text_document: TextDocumentIdentifier,
+}
+
+impl Request for VirtualTextDocument {
+    type Params = VirtualTextDocumentParams;
+    type Result = String;
+
+    const METHOD: &'static str = "deno/virtualTextDocument";
+}
+
+pub fn handle_virtual_locations(
+    meta: EditorMeta,
+    ctx: &mut Context,
+    mut virtual_locations: Vec<(ServerId, Location)>,
+    other_locations: Vec<(ServerId, Location)>,
+) {
+    let unique_uris: Vec<(ServerId, Uri)> = virtual_locations
+        .iter()
+        .map(|(server_id, Location { uri, .. })| (*server_id, uri.clone()))
+        .unique()
+        .collect();
+
+    let req_params: HashMap<usize, Vec<VirtualTextDocumentParams>> =
+        unique_uris
+            .iter()
+            .fold(HashMap::new(), |mut m, (server_id, uri)| {
+                m.entry(*server_id)
+                    .or_default()
+                    .push(VirtualTextDocumentParams {
+                        text_document: TextDocumentIdentifier {
+                            uri: (*uri).clone(),
+                        },
+                    });
+
+                m
+            });
+
+    ctx.call::<VirtualTextDocument, _>(
+        meta.clone(),
+        RequestParams::Each(req_params),
+        move |ctx, _, results| {
+            for ((_, uri), (_, content)) in unique_uris.into_iter().zip(results.into_iter()) {
+                _ = ctx.virtual_documents.insert(uri.to_string());
+                _ = ctx.documents.insert(
+                    uri.to_string(),
+                    Document {
+                        text: Rope::from_str(&content),
+                        version: meta.version,
+                    },
+                );
+            }
+
+            match virtual_locations.len() {
+                0 => {}
+                1 => goto_location(meta, virtual_locations.pop().unwrap(), ctx),
+                _ => {
+                    goto_locations(meta, other_locations, virtual_locations, ctx);
+                }
+            };
+        },
+    );
+}

--- a/src/language_features/document_symbol.rs
+++ b/src/language_features/document_symbol.rs
@@ -25,6 +25,7 @@ pub fn text_document_document_symbol(meta: EditorMeta, params: PositionParams, c
         .servers(&meta)
         .filter(|srv| attempt_server_capability(ctx, *srv, &meta, CAPABILITY_DOCUMENT_SYMBOL))
         .collect();
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, _)| {
@@ -32,7 +33,7 @@ pub fn text_document_document_symbol(meta: EditorMeta, params: PositionParams, c
                 server_id,
                 vec![DocumentSymbolParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     partial_result_params: Default::default(),
                     work_done_progress_params: Default::default(),
@@ -61,6 +62,7 @@ pub fn next_or_prev_symbol(meta: EditorMeta, params: NextOrPrevSymbolParams, ctx
         .servers(&meta)
         .filter(|srv| attempt_server_capability(ctx, *srv, &meta, CAPABILITY_DOCUMENT_SYMBOL))
         .collect();
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, _)| {
@@ -68,7 +70,7 @@ pub fn next_or_prev_symbol(meta: EditorMeta, params: NextOrPrevSymbolParams, ctx
                 server_id,
                 vec![DocumentSymbolParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     partial_result_params: Default::default(),
                     work_done_progress_params: Default::default(),
@@ -520,7 +522,7 @@ fn editor_next_or_prev_for_details(
         vec![HoverParams {
             text_document_position_params: TextDocumentPositionParams {
                 text_document: TextDocumentIdentifier {
-                    uri: file_path_to_uri(&meta.buffile),
+                    uri: ctx.uri_for_buffer(&meta.buffile),
                 },
                 position: get_lsp_position(server, &meta.buffile, &symbol_position, ctx).unwrap(),
             },
@@ -732,6 +734,7 @@ pub fn object(meta: EditorMeta, params: ObjectParams, ctx: &mut Context) {
         .servers(&meta)
         .filter(|srv| attempt_server_capability(ctx, *srv, &meta, CAPABILITY_DOCUMENT_SYMBOL))
         .collect();
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, _)| {
@@ -739,7 +742,7 @@ pub fn object(meta: EditorMeta, params: ObjectParams, ctx: &mut Context) {
                 server_id,
                 vec![DocumentSymbolParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     partial_result_params: Default::default(),
                     work_done_progress_params: Default::default(),
@@ -963,6 +966,7 @@ pub fn document_symbol_menu(meta: EditorMeta, params: GotoSymbolParams, ctx: &mu
         .servers(&meta)
         .filter(|srv| attempt_server_capability(ctx, *srv, &meta, CAPABILITY_DOCUMENT_SYMBOL))
         .collect();
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, _)| {
@@ -970,7 +974,7 @@ pub fn document_symbol_menu(meta: EditorMeta, params: GotoSymbolParams, ctx: &mu
                 server_id,
                 vec![DocumentSymbolParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     partial_result_params: Default::default(),
                     work_done_progress_params: Default::default(),
@@ -1149,6 +1153,7 @@ pub fn breadcrumbs(meta: EditorMeta, params: BreadcrumbsParams, ctx: &mut Contex
         .servers(&meta)
         .filter(|srv| attempt_server_capability(ctx, *srv, &meta, CAPABILITY_DOCUMENT_SYMBOL))
         .collect();
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, _)| {
@@ -1156,7 +1161,7 @@ pub fn breadcrumbs(meta: EditorMeta, params: BreadcrumbsParams, ctx: &mut Contex
                 server_id,
                 vec![DocumentSymbolParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     partial_result_params: Default::default(),
                     work_done_progress_params: Default::default(),

--- a/src/language_features/eclipse_jdt_ls.rs
+++ b/src/language_features/eclipse_jdt_ls.rs
@@ -1,12 +1,11 @@
 use super::code_action::apply_workspace_edit_editor_command;
 use crate::context::*;
 use crate::types::*;
-use crate::util::file_path_to_uri;
 use lsp_types::request::ExecuteCommand;
 use lsp_types::*;
 
 pub fn organize_imports(meta: EditorMeta, ctx: &mut Context) {
-    let file_uri = file_path_to_uri(&meta.buffile);
+    let file_uri = ctx.uri_for_buffer(&meta.buffile);
     let file_uri: String = file_uri.as_str().into();
 
     let req_params = ctx

--- a/src/language_features/formatting.rs
+++ b/src/language_features/formatting.rs
@@ -5,7 +5,6 @@ use crate::context::*;
 use crate::controller::can_serve;
 use crate::types::*;
 use crate::util::editor_quote;
-use crate::util::file_path_to_uri;
 use itertools::Itertools;
 use lsp_types::request::*;
 use lsp_types::*;
@@ -61,7 +60,7 @@ pub fn text_document_formatting(
         server_id,
         vec![DocumentFormattingParams {
             text_document: TextDocumentIdentifier {
-                uri: file_path_to_uri(&meta.buffile),
+                uri: ctx.uri_for_buffer(&meta.buffile),
             },
             options: params.clone(),
             work_done_progress_params: Default::default(),

--- a/src/language_features/goto.rs
+++ b/src/language_features/goto.rs
@@ -3,6 +3,7 @@ use crate::capabilities::{
     CAPABILITY_REFERENCES, CAPABILITY_TYPE_DEFINITION,
 };
 use crate::context::{Context, RequestParams};
+use crate::language_features::deno;
 use crate::position::*;
 use crate::types::{BackwardKakouneRange, EditorMeta, KakouneRange, PositionParams, ServerId};
 use crate::util::{editor_quote, short_file_path, uri_to_file_path};
@@ -54,10 +55,10 @@ pub fn goto(
     match locations.len() {
         0 => {}
         1 => {
-            goto_location(meta, &locations[0], ctx);
+            goto_location(meta, locations.into_iter().next().unwrap(), ctx);
         }
         _ => {
-            goto_locations(meta, &locations, ctx);
+            goto_locations(meta, locations, vec![], ctx);
         }
     }
 }
@@ -73,31 +74,98 @@ pub fn edit_at_range(buffile: &str, range: KakouneRange, in_normal_mode: bool) -
     )
 }
 
-fn goto_location(
+pub fn goto_location(
     meta: EditorMeta,
-    (server_id, Location { uri, range }): &(ServerId, Location),
+    (server_id, location): (ServerId, Location),
     ctx: &mut Context,
 ) {
+    let Location { uri, range } = &location;
+    let is_file = uri
+        .scheme()
+        .is_some_and(|scheme| scheme.eq_lowercase("file"));
+
     let path = uri_to_file_path(uri);
-    let path_str = path.to_str().unwrap();
+    let path_str = if is_file {
+        path.to_str().unwrap()
+    } else {
+        uri.as_str()
+    };
+
     if let Some(contents) = get_file_contents(path_str, ctx) {
-        let server = ctx.server(*server_id);
+        let server = ctx.server(server_id);
         let range = lsp_range_to_kakoune(range, &contents, server.offset_encoding);
-        let command = format!(
-            "evaluate-commands -try-client %opt{{jumpclient}} -- {}",
+        let command = formatdoc!(
+            "try %[
+                evaluate-commands -try-client %opt{{jumpclient}} -- {}
+            ] catch %[
+                evaluate-commands -try-client %opt{{jumpclient}} -- lsp-do-send kakoune/open-virtual-file {} {} {} {} {}
+            ]",
             editor_quote(&edit_at_range(path_str, range, true)),
+            editor_quote(path_str),
+            range.start.line,
+            range.start.column,
+            range.end.line,
+            range.end.column,
         );
         ctx.exec(meta, command);
+    } else if let Some(scheme) = uri.scheme() {
+        if scheme.eq_lowercase(deno::SCHEME) {
+            deno::handle_virtual_locations(meta, ctx, vec![(server_id, location)], vec![]);
+        }
     }
 }
 
-fn goto_locations(meta: EditorMeta, locations: &[(ServerId, Location)], ctx: &mut Context) {
+pub fn goto_locations(
+    meta: EditorMeta,
+    mut locations: Vec<(ServerId, Location)>,
+    virtual_locations: Vec<(ServerId, Location)>,
+    ctx: &mut Context,
+) {
+    if virtual_locations.is_empty() {
+        let (virtual_locations, non_virtual_locations): (Vec<_>, Vec<_>) = locations
+            .into_iter()
+            .partition(|(_, Location { uri, .. })| {
+                uri.scheme()
+                    .is_some_and(|scheme| !scheme.eq_lowercase("file"))
+            });
+
+        if !virtual_locations.is_empty() {
+            let (deno_locations, _): (Vec<_>, Vec<_>) =
+                virtual_locations
+                    .into_iter()
+                    .partition(|(_, Location { uri, .. })| {
+                        uri.scheme()
+                            .is_some_and(|scheme| scheme.eq_lowercase(deno::SCHEME))
+                    });
+
+            return deno::handle_virtual_locations(
+                meta,
+                ctx,
+                deno_locations,
+                non_virtual_locations,
+            );
+        }
+
+        locations = non_virtual_locations;
+    } else {
+        locations.extend(virtual_locations);
+    }
+
     let select_location = locations
         .iter()
-        .chunk_by(|(_, Location { uri, .. })| uri_to_file_path(uri))
+        .chunk_by(|(_, Location { uri, .. })| (uri_to_file_path(uri), uri))
         .into_iter()
-        .map(|(path, locations)| {
-            let path_str = path.to_str().unwrap();
+        .map(|((path, uri), locations)| {
+            let is_file = uri
+                .scheme()
+                .is_some_and(|scheme| scheme.eq_lowercase("file"));
+
+            let path_str = if is_file {
+                path.to_str().unwrap()
+            } else {
+                uri.as_str()
+            };
+
             let contents = match get_file_contents(path_str, ctx) {
                 Some(contents) => contents,
                 None => return "".into(),
@@ -109,11 +177,21 @@ fn goto_locations(meta: EditorMeta, locations: &[(ServerId, Location)], ctx: &mu
                     if range.start.line as usize >= contents.len_lines() {
                         return "".into();
                     }
+
+                    let file_path = if uri
+                        .scheme()
+                        .is_some_and(|scheme| scheme.eq_lowercase("file"))
+                    {
+                        short_file_path(path_str, ctx.main_root(&meta))
+                    } else {
+                        uri.as_str()
+                    };
+
                     // Let's use the main server root path to dictate how
                     // file paths should look like in the goto buffer.
                     format!(
                         "{}:{}:{}:{}",
-                        short_file_path(path_str, ctx.main_root(&meta)),
+                        file_path,
                         pos.line,
                         pos.column,
                         contents.line(range.start.line as usize),

--- a/src/language_features/goto.rs
+++ b/src/language_features/goto.rs
@@ -5,7 +5,7 @@ use crate::capabilities::{
 use crate::context::{Context, RequestParams};
 use crate::position::*;
 use crate::types::{BackwardKakouneRange, EditorMeta, KakouneRange, PositionParams, ServerId};
-use crate::util::{editor_quote, file_path_to_uri, short_file_path, uri_to_file_path};
+use crate::util::{editor_quote, short_file_path, uri_to_file_path};
 use indoc::formatdoc;
 use itertools::Itertools;
 use lsp_types::request::{
@@ -147,6 +147,7 @@ pub fn text_document_definition(
         );
         return;
     }
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, server_settings)| {
@@ -154,9 +155,7 @@ pub fn text_document_definition(
                 server_id,
                 vec![GotoDefinitionParams {
                     text_document_position_params: TextDocumentPositionParams {
-                        text_document: TextDocumentIdentifier {
-                            uri: file_path_to_uri(&meta.buffile),
-                        },
+                        text_document: TextDocumentIdentifier { uri: uri.clone() },
                         position: get_lsp_position(
                             server_settings,
                             &meta.buffile,
@@ -197,6 +196,7 @@ pub fn text_document_implementation(meta: EditorMeta, params: PositionParams, ct
         );
         return;
     }
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, server_settings)| {
@@ -204,9 +204,7 @@ pub fn text_document_implementation(meta: EditorMeta, params: PositionParams, ct
                 server_id,
                 vec![GotoDefinitionParams {
                     text_document_position_params: TextDocumentPositionParams {
-                        text_document: TextDocumentIdentifier {
-                            uri: file_path_to_uri(&meta.buffile),
-                        },
+                        text_document: TextDocumentIdentifier { uri: uri.clone() },
                         position: get_lsp_position(
                             server_settings,
                             &meta.buffile,
@@ -240,6 +238,7 @@ pub fn text_document_type_definition(meta: EditorMeta, params: PositionParams, c
         );
         return;
     }
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, server_settings)| {
@@ -247,9 +246,7 @@ pub fn text_document_type_definition(meta: EditorMeta, params: PositionParams, c
                 server_id,
                 vec![GotoDefinitionParams {
                     text_document_position_params: TextDocumentPositionParams {
-                        text_document: TextDocumentIdentifier {
-                            uri: file_path_to_uri(&meta.buffile),
-                        },
+                        text_document: TextDocumentIdentifier { uri: uri.clone() },
                         position: get_lsp_position(
                             server_settings,
                             &meta.buffile,
@@ -283,6 +280,7 @@ pub fn text_document_references(meta: EditorMeta, params: PositionParams, ctx: &
         );
         return;
     }
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, server_settings)| {
@@ -290,9 +288,7 @@ pub fn text_document_references(meta: EditorMeta, params: PositionParams, ctx: &
                 server_id,
                 vec![ReferenceParams {
                     text_document_position: TextDocumentPositionParams {
-                        text_document: TextDocumentIdentifier {
-                            uri: file_path_to_uri(&meta.buffile),
-                        },
+                        text_document: TextDocumentIdentifier { uri: uri.clone() },
                         position: get_lsp_position(
                             server_settings,
                             &meta.buffile,

--- a/src/language_features/highlight.rs
+++ b/src/language_features/highlight.rs
@@ -7,7 +7,6 @@ use crate::types::{
     PositionParams, ServerId,
 };
 use crate::util::editor_quote;
-use crate::util::file_path_to_uri;
 use itertools::Itertools;
 use lsp_types::{
     request::DocumentHighlightRequest, DocumentHighlight, DocumentHighlightKind,
@@ -26,6 +25,7 @@ pub fn text_document_highlight(meta: EditorMeta, params: PositionParams, ctx: &m
     let (first_server, _) = *eligible_servers.first().unwrap();
     let first_server = first_server.to_owned();
 
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, server_settings)| {
@@ -34,7 +34,7 @@ pub fn text_document_highlight(meta: EditorMeta, params: PositionParams, ctx: &m
                 vec![DocumentHighlightParams {
                     text_document_position_params: TextDocumentPositionParams {
                         text_document: TextDocumentIdentifier {
-                            uri: file_path_to_uri(&meta.buffile),
+                            uri: uri.clone(),
                         },
                         position: get_lsp_position(
                             server_settings,

--- a/src/language_features/hover.rs
+++ b/src/language_features/hover.rs
@@ -9,7 +9,6 @@ use crate::markup::*;
 use crate::mkfifo;
 use crate::position::*;
 use crate::types::*;
-use crate::util::file_path_to_uri;
 use indoc::formatdoc;
 use itertools::Itertools;
 use lsp_types::request::*;
@@ -31,6 +30,7 @@ pub fn text_document_hover(meta: EditorMeta, params: EditorHoverParams, ctx: &mu
     let tabstop = params.tabstop;
 
     let (range, cursor) = parse_kakoune_range(&params.selection_desc);
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, server_settings)| {
@@ -39,7 +39,7 @@ pub fn text_document_hover(meta: EditorMeta, params: EditorHoverParams, ctx: &mu
                 vec![HoverParams {
                     text_document_position_params: TextDocumentPositionParams {
                         text_document: TextDocumentIdentifier {
-                            uri: file_path_to_uri(&meta.buffile),
+                            uri: uri.clone(),
                         },
                         position: get_lsp_position(server_settings, &meta.buffile, &cursor, ctx)
                             .unwrap(),

--- a/src/language_features/inlay_hints.rs
+++ b/src/language_features/inlay_hints.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     text_edit::apply_text_edits,
     types::{EditorMeta, ServerId},
-    util::{editor_quote, escape_tuple_element, file_path_to_uri},
+    util::{editor_quote, escape_tuple_element},
 };
 
 #[derive(Debug, PartialEq, Clone, Default)]
@@ -32,6 +32,7 @@ pub fn inlay_hints(meta: EditorMeta, params: InlayHintsOptions, ctx: &mut Contex
         return;
     }
 
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, _)| {
@@ -40,7 +41,7 @@ pub fn inlay_hints(meta: EditorMeta, params: InlayHintsOptions, ctx: &mut Contex
                 vec![InlayHintParams {
                     work_done_progress_params: Default::default(),
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     range: Range::new(Position::new(0, 0), Position::new(params.buf_line_count, 0)),
                 }],
@@ -230,7 +231,7 @@ pub fn inlay_hint_apply(meta: EditorMeta, params: InlayHintApplyParams, ctx: &mu
             continue;
         }
 
-        let uri = file_path_to_uri(&meta.buffile);
+        let uri = ctx.uri_for_buffer(&meta.buffile);
 
         // FIXME: https://github.com/kakoune-lsp/kakoune-lsp/issues/873
         // we expect this to break if multiple servers provide InlayHints with textedits

--- a/src/language_features/lean.rs
+++ b/src/language_features/lean.rs
@@ -72,6 +72,7 @@ pub fn plain_goal_impl<
     params: EditorPlainGoalParams,
     ctx: &mut Context,
 ) {
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = ctx
         .servers(&meta)
         .map(|(server_id, server_settings)| {
@@ -79,7 +80,7 @@ pub fn plain_goal_impl<
                 server_id,
                 vec![R::Params {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     position: get_lsp_position(
                         server_settings,

--- a/src/language_features/mod.rs
+++ b/src/language_features/mod.rs
@@ -5,6 +5,7 @@ pub mod code_action;
 pub mod code_lens;
 pub mod completion;
 pub mod cquery;
+pub mod deno;
 pub mod document_symbol;
 pub mod eclipse_jdt_ls;
 pub mod formatting;

--- a/src/language_features/range_formatting.rs
+++ b/src/language_features/range_formatting.rs
@@ -7,7 +7,6 @@ use crate::position::{kakoune_range_to_lsp, parse_kakoune_range};
 use crate::text_edit::{apply_text_edits_to_buffer, TextEditish};
 use crate::types::*;
 use crate::util::editor_quote;
-use crate::util::file_path_to_uri;
 use itertools::Itertools;
 use lsp_types::request::*;
 use lsp_types::*;
@@ -68,6 +67,7 @@ pub fn text_document_range_formatting(
     };
 
     let (server_id, server) = eligible_servers[0];
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let mut req_params = HashMap::new();
     req_params.insert(
         server_id,
@@ -80,7 +80,7 @@ pub fn text_document_range_formatting(
             })
             .map(|range| DocumentRangeFormattingParams {
                 text_document: TextDocumentIdentifier {
-                    uri: file_path_to_uri(&meta.buffile),
+                    uri: uri.clone(),
                 },
                 range,
                 options: params.formatting_options.clone(),

--- a/src/language_features/rename.rs
+++ b/src/language_features/rename.rs
@@ -1,7 +1,6 @@
 use crate::context::*;
 use crate::position::*;
 use crate::types::*;
-use crate::util::file_path_to_uri;
 
 use lsp_types::request::*;
 use lsp_types::*;
@@ -9,6 +8,7 @@ use lsp_types::*;
 use super::super::workspace;
 
 pub fn text_document_rename(meta: EditorMeta, params: TextDocumentRenameParams, ctx: &mut Context) {
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = ctx
         .servers(&meta)
         .map(|(server_id, server_settings)| {
@@ -17,7 +17,7 @@ pub fn text_document_rename(meta: EditorMeta, params: TextDocumentRenameParams, 
                 vec![RenameParams {
                     text_document_position: TextDocumentPositionParams {
                         text_document: TextDocumentIdentifier {
-                            uri: file_path_to_uri(&meta.buffile),
+                            uri: uri.clone(),
                         },
                         position: get_lsp_position(
                             server_settings,

--- a/src/language_features/rust_analyzer.rs
+++ b/src/language_features/rust_analyzer.rs
@@ -2,7 +2,7 @@ use crate::context::{Context, RequestParams};
 use crate::position::{get_lsp_position, lsp_position_to_kakoune};
 use crate::text_edit::apply_text_edits_try_deferred;
 use crate::types::{EditorMeta, KakounePosition, PositionParams};
-use crate::util::{editor_escape, editor_quote, file_path_to_uri, uri_to_file_path};
+use crate::util::{editor_escape, editor_quote, uri_to_file_path};
 use crate::{workspace, ResponseFifo};
 use itertools::Itertools;
 use lsp_types::request::Request;
@@ -157,6 +157,7 @@ impl Request for ExpandMacroRequest {
 }
 
 pub fn expand_macro(meta: EditorMeta, params: PositionParams, ctx: &mut Context) {
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = ctx
         .servers(&meta)
         .map(|(server_id, server_settings)| {
@@ -164,7 +165,7 @@ pub fn expand_macro(meta: EditorMeta, params: PositionParams, ctx: &mut Context)
                 server_id,
                 vec![ExpandMacroParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     position: get_lsp_position(
                         server_settings,

--- a/src/language_features/selection_range.rs
+++ b/src/language_features/selection_range.rs
@@ -1,7 +1,6 @@
 use crate::context::*;
 use crate::position::*;
 use crate::types::*;
-use crate::util::file_path_to_uri;
 use indoc::formatdoc;
 use itertools::Itertools;
 use lsp_types::request::*;
@@ -28,6 +27,7 @@ pub fn text_document_selection_range(
             return;
         }
     };
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = ctx
         .servers(&meta)
         .map(|(server_id, server_settings)| {
@@ -47,7 +47,7 @@ pub fn text_document_selection_range(
                 server_id,
                 vec![SelectionRangeParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     positions: cursor_positions,
                     work_done_progress_params: WorkDoneProgressParams::default(),

--- a/src/language_features/semantic_tokens.rs
+++ b/src/language_features/semantic_tokens.rs
@@ -4,7 +4,6 @@ use crate::position::lsp_range_to_kakoune;
 use crate::semantic_tokens_config;
 use crate::types::{EditorMeta, ForwardKakouneRange, ServerId};
 use crate::util::editor_quote;
-use crate::util::file_path_to_uri;
 use lsp_types::request::SemanticTokensFullRequest;
 use lsp_types::{
     Position, Range, SemanticToken, SemanticTokenModifier, SemanticTokensOptions,
@@ -24,6 +23,7 @@ pub fn tokens_request(meta: EditorMeta, ctx: &mut Context) {
     let (first_server, _) = *eligible_servers.first().unwrap();
     let first_server = first_server.to_owned();
 
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, _)| {
@@ -32,7 +32,7 @@ pub fn tokens_request(meta: EditorMeta, ctx: &mut Context) {
                 vec![SemanticTokensParams {
                     partial_result_params: Default::default(),
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     work_done_progress_params: Default::default(),
                 }],

--- a/src/language_features/signature_help.rs
+++ b/src/language_features/signature_help.rs
@@ -21,6 +21,7 @@ pub fn text_document_signature_help(meta: EditorMeta, params: PositionParams, ct
     let (first_server, _) = *eligible_servers.first().unwrap();
     let first_server = first_server.to_owned();
 
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, server_settings)| {
@@ -30,7 +31,7 @@ pub fn text_document_signature_help(meta: EditorMeta, params: PositionParams, ct
                     context: None,
                     text_document_position_params: TextDocumentPositionParams {
                         text_document: TextDocumentIdentifier {
-                            uri: file_path_to_uri(&meta.buffile),
+                            uri: uri.clone(),
                         },
                         position: get_lsp_position(
                             server_settings,

--- a/src/language_features/texlab.rs
+++ b/src/language_features/texlab.rs
@@ -5,7 +5,6 @@ use crate::capabilities::{
 use crate::context::{Context, RequestParams};
 use crate::position::get_lsp_position;
 use crate::types::EditorMeta;
-use crate::util::file_path_to_uri;
 use crate::PositionParams;
 use lsp_types::request::Request;
 use lsp_types::TextDocumentIdentifier;
@@ -61,6 +60,7 @@ pub fn forward_search(meta: EditorMeta, params: PositionParams, ctx: &mut Contex
         return;
     }
 
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, server_settings)| {
@@ -68,7 +68,7 @@ pub fn forward_search(meta: EditorMeta, params: PositionParams, ctx: &mut Contex
                 server_id,
                 vec![TextDocumentPositionParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                     position: get_lsp_position(
                         server_settings,
@@ -145,6 +145,7 @@ pub fn build(meta: EditorMeta, ctx: &mut Context) {
         ctx.show_error(meta, format!("no server supports {}", Build::METHOD));
         return;
     }
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let req_params = eligible_servers
         .into_iter()
         .map(|(server_id, _server_settings)| {
@@ -152,7 +153,7 @@ pub fn build(meta: EditorMeta, ctx: &mut Context) {
                 server_id,
                 vec![BuildTextDocumentParams {
                     text_document: TextDocumentIdentifier {
-                        uri: file_path_to_uri(&meta.buffile),
+                        uri: uri.clone(),
                     },
                 }],
             )

--- a/src/text_sync.rs
+++ b/src/text_sync.rs
@@ -34,7 +34,7 @@ pub fn text_document_did_open(
 
     let params = DidOpenTextDocumentParams {
         text_document: TextDocumentItem {
-            uri: file_path_to_uri(&meta.buffile),
+            uri: ctx.uri_for_buffer(&meta.buffile),
             language_id: meta.language_id.clone(),
             version: meta.version,
             text: params.draft,
@@ -50,7 +50,7 @@ pub fn text_document_did_change(
     params: TextDocumentDidChangeParams,
     ctx: &mut Context,
 ) {
-    let uri = file_path_to_uri(&meta.buffile);
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let version = meta.version;
     let old_version = ctx
         .documents
@@ -87,7 +87,7 @@ pub fn text_document_did_change(
 
 pub fn text_document_did_close(meta: EditorMeta, ctx: &mut Context) {
     ctx.documents.remove(&meta.buffile);
-    let uri = file_path_to_uri(&meta.buffile);
+    let uri = ctx.uri_for_buffer(&meta.buffile);
     let params = DidCloseTextDocumentParams {
         text_document: TextDocumentIdentifier { uri },
     };
@@ -116,7 +116,7 @@ pub fn text_document_did_save(meta: EditorMeta, ctx: &mut Context) {
             _ => None,
         };
 
-        let uri = file_path_to_uri(&meta.buffile);
+        let uri = ctx.uri_for_buffer(&meta.buffile);
         let params = DidSaveTextDocumentParams {
             text_document: TextDocumentIdentifier { uri },
             text,

--- a/src/types.rs
+++ b/src/types.rs
@@ -510,6 +510,13 @@ pub struct SelectionRangePositionParams {
     pub selections_desc: Vec<String>,
 }
 
+#[derive(Clone, Debug)]
+pub struct OpenVirtualFileParams {
+    pub uri: String,
+    pub start: KakounePosition,
+    pub end: KakounePosition,
+}
+
 // Language Server
 
 // XXX serde(untagged) ?

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,6 @@
+use crate::context::Context;
 use crate::types::*;
+use indoc::formatdoc;
 use lsp_types::Uri;
 use std::os::unix::fs::DirBuilderExt;
 use std::path::PathBuf;
@@ -153,4 +155,35 @@ pub fn uri_to_file_path(uri: &Uri) -> PathBuf {
         .unwrap()
         .to_file_path()
         .unwrap()
+}
+
+pub fn open_virtual_file(
+    ctx: &Context,
+    meta: EditorMeta,
+    uri: &str,
+    range: KakouneRange,
+    contents: &str,
+) {
+    let fifo = mkfifo(ctx.to_editor());
+    let client = meta.client.as_ref().unwrap();
+    let command = format!(
+        "%[
+            edit! -readonly -fifo {fifo} {uri}; \
+            hook -once buffer BufCloseFifo .* %[
+                nop %sh[ rm {fifo} ]; \
+                evaluate-commands -try-client {client} %[
+                    edit -existing -readonly {uri}
+                    select {}; \
+                    execute-keys <c-s>vv; \
+                    lsp-unblock-in-buffer; \
+                ]
+            ]
+        ]",
+        BackwardKakouneRange(range),
+    );
+
+    // Write to fifo in draft context so that the buffer isn't focused right away.
+    let command = formatdoc!("evaluate-commands -draft {command}");
+    ctx.exec(meta, command);
+    let _ = std::fs::write(&fifo, contents);
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Needs https://github.com/kakoune-lsp/kakoune-lsp/pull/884 first as base.

More details in the commits themselves but, basically, some servers use virtual documents to show definitions. Deno does that because the source of its core is embedded in Deno itself, not in files.

This merge request allows handling those virtual documents by creating temporary files for them. Same path, same hash, which means the same temporary file can be used between different projects.

Also, this merge request also correctly maps those temporary files back to their virtual URI, so that the LSP can still function accordingly inside those files.

The way the code is structured allows easily plugging in virtual document handlers for other LSP servers as well.