### PR TITLE
feat: sourcekit lsp support for Swift filetype

### DIFF
--- a/rc/servers.kak
+++ b/rc/servers.kak
@@ -22,6 +22,13 @@ hook -group lsp-filetype-c-family global BufSetOption filetype=(?:c|cpp|objc) %{
     }
 }
 
+hook -group lsp-filetype-swift global BufSetOption filetype=(?:swift) %{
+    set-option buffer lsp_servers %{
+        [sourcekit-lsp]
+        root_globs = ["Package.swift", ".xcodeproj", ".git", ".hg"]
+    }
+}
+
 hook -group lsp-filetype-clojure global BufSetOption filetype=clojure %{
     set-option buffer lsp_servers %{
         [clojure-lsp]


### PR DESCRIPTION
- added sourcekit-lsp configuration for Swift filetype
- root detection includes Package.swift and .xcodeproj files