### PR TITLE
Fix tinymist config

### DIFF
--- a/rc/servers.kak
+++ b/rc/servers.kak
@@ -669,7 +669,7 @@ hook -group lsp-filetype-typst global BufSetOption filetype=typst %{
         args = ["lsp"]
         settings_section = "_"
         [tinymist.settings._]
-        # See https://myriad-dreamin.github.io/tinymist/configurations.html
+        # See https://myriad-dreamin.github.io/tinymist/config/neovim.html
         exportPdf = "onDocumentHasTitle"
         formatterMode = "typstyle"
         preview.background.enabled = false

--- a/rc/servers.kak
+++ b/rc/servers.kak
@@ -672,7 +672,7 @@ hook -group lsp-filetype-typst global BufSetOption filetype=typst %{
         # See https://myriad-dreamin.github.io/tinymist/configurations.html
         exportPdf = "onDocumentHasTitle"
         formatterMode = "typstyle"
-        previewFeature = "disable"
+        preview.background.enabled = false
     }
     set-option -add buffer lsp_servers "formatterPrintWidth = %opt{autowrap_column}"
 }


### PR DESCRIPTION

- Fix tinymist preview config key. `previewFeature` only works for the vscode plugin
- Fix tinymist documentation URL
