### PR TITLE
lsp-send-buffer: use buffer scope for finaleol override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Breaking changes:
 - `nixd` replaces `nil` as default language server for nix (#890).
 
+Fixes:
+- Fix buffer-sync corruption when `.editorconfig` sets `insert_final_newline = false` (#891).
+
 ## 20.0.0 - 2026-04-16
 
 Breaking changes:

--- a/rc/lsp.kak
+++ b/rc/lsp.kak
@@ -686,10 +686,14 @@ define-command -hidden lsp-if-changed-since -params 3 -docstring %{
     }
 }
 
+declare-option -hidden str lsp_saved_finaleol
+
 define-command -hidden lsp-send-buffer -params 1 %{
-    try %{ set-option local finaleol present }
+    try %{ set-option buffer lsp_saved_finaleol %opt{finaleol} }
+    try %{ set-option buffer finaleol present }
     lsp-send %arg{1} %val{buf_line_count}
     evaluate-commands -no-hooks %{ write -force %opt{lsp_alt_fifo} }
+    try %{ set-option buffer finaleol %opt{lsp_saved_finaleol} }
 }
 
 define-command -hidden lsp-did-change -docstring "Notify language server about buffer change" %{


### PR DESCRIPTION
## Problem

The fix in 9bc804d uses `set-option local finaleol present`, but `local` is a context-local scope that is empty in normal hook-fired contexts. `set-option local` throws "no such scope: 'local'" and the surrounding `try {}` swallows it silently: the override never takes effect.

## Symptom

When `.editorconfig` sets `insert_final_newline = false`, Kakoune's editorconfig integration sets `buffer finaleol missing`. With the override silently failing, `write -force <alt-fifo>` skips the trailing newline. Consecutive writes (e.g. didOpen followed by didChange) get spliced across message boundaries in `text_of_buffer`, and the language server receives a buffer whose last line has the file's first line concatenated onto it.

For Zig this surfaces as zls reporting `duplicate struct member name 'std'` at line 1, against a phantom duplicate on the last line.

## Fix

Use the `buffer` scope (which always resolves) and save/restore the previous value so the editorconfig preference is honoured for ordinary `:write`.

## Repro

Any file in a project whose `.editorconfig` sets `insert_final_newline = false`, with any LSP that diagnoses duplicate top-level identifiers (zls works). Requires Kakoune with [`600c418eb6`](https://github.com/mawww/kakoune/commit/600c418eb6).