### PR TITLE
fix: handle sourcekit-lsp semantic tokens option parsing error

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -2004,7 +2004,18 @@ fn dispatch_server_request(
                             continue;
                         };
                         let semantic_tokens_options: SemanticTokensOptions =
-                            serde_json::from_value(options).unwrap();
+                            // sourcekit-lsp shipped with Xcode 27.beta1 workaround
+                            match serde_json::from_value(options) {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    warn!(
+                                        ctx.to_editor(),
+                                        "Failed to parse semantic tokens options: {}",
+                                        e
+                                    );
+                                    continue;
+                                }
+                            };
                         let semantic_tokens_server_capabilities =
                             SemanticTokensServerCapabilities::SemanticTokensRegistrationOptions(
                                 SemanticTokensRegistrationOptions {


### PR DESCRIPTION
Gracefully handle potential parsing errors for semantic tokens options to fix a panic with sourcekit-lsp from Xcode 27.beta1.